### PR TITLE
fix(dependencies): update dependency to ladybug-core

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+lbt-ladybug
 ladybug-geometry
 coverage==4.5.2
 coveralls==1.5.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/ladybug-tools/honeybee-core",
     packages=setuptools.find_packages(exclude=["tests"]),
-    install_requires=["ladybug-geometry"],
+    install_requires=["lbt-ladybug", "ladybug-geometry"],
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
As discussed today I changed the dependency from `ladybug-geometry` to `lbt-ladybug`. With this change all the libraries that are using `honeybee-core` will also have access to `ladybug-core` features.

This will fix the currently failing tests for honeybee-radiance:
https://travis-ci.org/ladybug-tools/honeybee-radiance/jobs/543996323