### PR TITLE
feat(typing): Adding a module to assist with type checking

### DIFF
--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -2,6 +2,7 @@
 """Honeybee Face."""
 from .properties import Properties
 from .facetype import get_type_from_normal
+from .typing import valid_string
 import honeybee.writer as writer
 from ladybug_geometry.geometry3d.face import Face3D
 from ladybug_geometry.geometry3d.pointvector import Point3D
@@ -12,6 +13,7 @@ import weakref
 
 class Face(object):
     """A single planar face."""
+    _name_descr = 'honeybee face name'
 
     def __init__(self, name, geometry, face_type=None, boundary_condition=None):
         """A single planar face.
@@ -41,7 +43,7 @@ class Face(object):
 
     @name.setter
     def name(self, value):
-        self._name = re.sub(r'[^.A-Za-z0-9_-]', '', value)
+        self._name = valid_string(value, self._name_descr)
         self._name_original = value
 
     @property
@@ -76,7 +78,7 @@ class Face(object):
     @boundary_condition.setter
     def boundary_condition(self, bc):
         self._properties.boundary_condition = bc
-    
+
     @property
     def apertures(self):
         """List of apertures."""
@@ -120,7 +122,7 @@ class Face(object):
 
     def to_dict(self, included_prop=None):
         """Return Face as a dictionary.
-        
+
         args:
             included_prop: Use properties filter to filter keys that must be included in
             output dictionary. For example ['energy'] will include 'energy' key if

--- a/honeybee/typing.py
+++ b/honeybee/typing.py
@@ -1,0 +1,123 @@
+"""Collection of methods for type input checking."""
+import re
+
+
+def valid_string(value, input_name=''):
+    """Get a valid string for both Radaince and EnergyPlus.
+
+    This is used for honeybee face and honeybee zone names.
+    """
+    try:
+        val = re.sub(r'[^.A-Za-z0-9_-]', '', value)
+    except TypeError:
+        raise TypeError('Input {} must be a text string. Got {}.'.format(
+            input_name, type(value)))
+    assert len(val) > 0, 'Input {} "{}" contains no valid characters.'.format(
+        input_name, value)
+    assert len(val) <= 100, 'Input {} "{}" must be less than 100 characters.'.format(
+        input_name, value)
+    return val
+
+
+def valid_rad_string(value, input_name=''):
+    """Get a valid string for Radaince that can be used for rad material names, etc.
+
+    This includes stripping out illegal characters and white spaces.
+    """
+    try:
+        val = re.sub(r'[^.A-Za-z0-9_-]', '', value)
+    except TypeError:
+        raise TypeError('Input {} must be a text string. Got {}.'.format(
+            input_name, type(value)))
+    assert len(val) > 0, 'Input {} "{}" contains no valid characters.'.format(
+        input_name, value)
+    return val
+
+
+def valid_ep_string(value, input_name=''):
+    """Get valid string for EnergyPlus that can be used for energy material names, etc.
+
+    This includes stripping out all illegal characters, removing trailing white spaces,
+    and ensuring the name is not longer than 100 characters.
+    """
+    try:
+        val = re.sub(r'[^.\sA-Za-z0-9_-]', '', value)
+    except TypeError:
+        raise TypeError('Input {} must be a text string. Got {}.'.format(
+            input_name, type(value)))
+    val = val.strip()
+    assert len(val) > 0, 'Input {} "{}" contains no valid characters.'.format(
+        input_name, value)
+    assert len(val) <= 100, 'Input {} "{}" must be less than 100 characters.'.format(
+        input_name, value)
+    return val
+
+
+def float_in_range(value, mi=0.0, ma=1.0, input_name=''):
+    """Check a float value to be between minimum and maximum."""
+    try:
+        number = float(value)
+    except (ValueError, TypeError):
+        raise TypeError('Input {} must be a number. Got {}.'.format(
+            input_name, type(value)))
+    assert mi <= number <= ma, 'Input number {} must be between {} and {}. ' \
+        'Got {}'.format(input_name, mi, ma, value)
+    return number
+
+
+def int_in_range(value, mi=0.0, ma=1.0, input_name=''):
+    """Check an integer value to be between minimum and maximum."""
+    try:
+        number = int(value)
+    except (ValueError, TypeError):
+        raise TypeError('Input {} must be an integer. Got {}.'.format(
+            input_name, type(value)))
+    assert mi <= number <= ma, 'Input integer {} must be between {} and {}. ' \
+        'Got {}.'.format(input_name, mi, ma, value)
+    return number
+
+
+def float_positive(value, input_name=''):
+    """Check a float value to be positive."""
+    try:
+        number = float(value)
+    except (ValueError, TypeError):
+        raise TypeError('Input {} must be a number. Got {}.'.format(
+            input_name, type(value)))
+    assert 0 <= number, 'Input {} "{}" must be positive.'.format(input_name, number)
+    return number
+
+
+def int_positive(value, input_name=''):
+    """Check if an integer value is positive."""
+    try:
+        number = int(value)
+    except (ValueError, TypeError):
+        raise TypeError('Input {} must be an integer. Got {}.'.format(
+            input_name, type(value)))
+    assert 0 <= number, 'Input {} ({}) must be positive.'.format(input_name, number)
+    return number
+
+
+def tuple_with_length(value, length=3, item_type=float, input_name=''):
+    """Try to create a tuple with a certain value."""
+    try:
+        value = tuple(item_type(v) for v in value)
+    except (ValueError, TypeError):
+        raise TypeError('Input {} must be a {}.'.format(
+            input_name, item_type))
+    assert len(value) == length, 'Input {} length must be {} not {}'.format(
+        input_name, length, len(value))
+    return value
+
+
+def list_with_length(value, length=3, item_type=float, input_name=''):
+    """Try to create a list with a certain value."""
+    try:
+        value = [item_type(v) for v in value]
+    except (ValueError, TypeError):
+        raise TypeError('Input {} must be a {}.'.format(
+            input_name, item_type))
+    assert len(value) == length, 'Input {} length must be {} not {}'.format(
+        input_name, length, len(value))
+    return value


### PR DESCRIPTION
This adds the typing module to honeybee core as we discussed @mostaphaRoudsari .  I also set the name of the honeybee Face to use the type checking such that it is always valid for both E+ and Radiance.

Note that, with this implementation, an error will be raised for all honeybee face names that exceed 100 characters after stripping out illegal characters.  I don't know if we should be adding an extra setter for `name_original` so that we can set this to be the crazy-long Revit name if we so desire. Just let me know if you think we should have a separate setter and I can add it.