### PR TITLE
feat(objects): Adding objects for zone, aperture, and door

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ![Honeybee](http://www.ladybug.tools/assets/img/honeybee.png)
 
+[![Build Status](https://travis-ci.org/ladybug-tools/honeybee-core.svg?branch=master)](https://travis-ci.org/ladybug-tools/honeybee-core)
+[![Coverage Status](https://coveralls.io/repos/github/ladybug-tools/honeybee-core/badge.svg?branch=master)](https://coveralls.io/github/ladybug-tools/honeybee-core)
+
+[![Python 2.7](https://img.shields.io/badge/python-2.7-green.svg)](https://www.python.org/downloads/release/python-270/) [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/) [![IronPython](https://img.shields.io/badge/ironpython-2.7-red.svg)](https://github.com/IronLanguages/ironpython2/releases/tag/ipy-2.7.8/)
+
 # honeybee-core
 
 Honeybee core library.

--- a/honeybee/_lockable.py
+++ b/honeybee/_lockable.py
@@ -1,0 +1,96 @@
+# coding=utf-8
+"""Descriptor that for locking and unlocking an object, preventing attrbute setting."""
+from functools import wraps
+from inspect import getmro
+
+
+def lockable(cls):
+    """A decorator for making lockable class.
+
+    If a class is locked, attributes can no longer be set on the class.
+    The class will throw an AttributeError if one tries to do so.
+
+    Classes start out as unlocked but can be locked by calling the `lock()` method.
+    If the class needs to be unlocked again, calling the `unlock()` method will
+    unlock it and allow you to edit attributes on the class.  You can also create
+    a class that starts out as locked by putting `self._locked = True` at the end
+    of a class's `__init__` method.
+
+    Note that classes using __slots__ must specify a '_locked' variable within
+    the __slots__ in order to work correctly with this decorator.
+
+    This example if modified from:
+    http://stackoverflow.com/questions/3603502/prevent-creating-new-attributes-outside-init
+
+    Usage:
+        @lockable
+        class Foo(object):
+            def __init__(self):
+                self.bar = 10
+
+        foo = Foo()
+        foo.bar = 20
+
+        foo.lock()
+        try:
+            foo.bar = 30
+        except AttributeError as e:
+            print(e)
+        > Failed to set bar to 30. bar cannot be set on Foo while it is locked.
+          The unlock() method can unlock the class but you do so at your own risk.
+          Objects are typically locked when they are referenced from many other objects.
+          So it is usually better to make a new instance of Foo and proceed using that.
+
+        foo.unlock()
+        foo.bar = 30
+        foo.lock()
+    """
+
+    def lockedsetattr(self, key, value):
+        """Method to overwrite __setattr__ on the decorated class."""
+        if hasattr(self, '_locked') and self._locked and not key == '_locked':
+            raise AttributeError(
+                'Failed to set {1} to {2}. {1} cannot be set on {0} while it is locked.'
+                '\nThe unlock() method can unlock the class but you do so at '
+                'your own risk.\nObjects are typically locked when they are referenced '
+                'from several other objects.\n So it is usually better practice to'
+                'make a new instance of {0} and proceed using that.'.format(
+                    cls.__name__, key, value))
+        else:
+            object.__setattr__(self, key, value)
+
+    def init_decorator(func):
+        """Initialize the locabke decorator for the class."""
+
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            func(self, *args, **kwargs)
+        return wrapper
+
+    def lock(self):
+        self._locked = True
+
+    def unlock(self):
+        self._locked = False
+
+    # overwrite the various methods on the class to support lockability
+    cls.__setattr__ = lockedsetattr
+    cls.__init__ = init_decorator(cls.__init__)
+    if not hasattr(cls, 'lock'):  # allow developers to add their own lock method
+        cls.lock = lock
+    if not hasattr(cls, 'unlock'):  # allow developers to add their own unlock method
+        cls.unlock = unlock
+
+    # if the class uses __slots__, check that _locked is somewhere in inheritance tree
+    if hasattr(cls, '__slots__'):
+        _all_good = False
+        for parent_class in getmro(cls)[:-1]:
+            if '_locked' in parent_class.__slots__:
+                _all_good = True
+                break
+        if not _all_good:
+            raise AttributeError(
+                'When using the @locakble decorator on a class with __slots__, '
+                'a "_locked" variable must be specified within __slots__.')
+
+    return cls

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -1,0 +1,535 @@
+# coding: utf-8
+"""Honeybee Aperture."""
+from .properties import ApertureProperties
+from .aperturetype import aperture_types
+from .boundarycondition import boundary_conditions, Outdoors, Surface
+from .shade import Shade
+from .typing import valid_string
+import honeybee.writer as writer
+
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.face import Face3D
+
+import math
+
+
+class Aperture(object):
+    """A single planar aperture face.
+
+    Properties:
+        name
+        name_original
+        geometry
+        vertices
+        upper_left_vertices
+        triangulated_mesh3d
+        normal
+        center
+        area
+        perimeter
+        type
+        boundary_condition
+        parent
+        has_parent
+    """
+    TYPES = aperture_types
+    __slots__ = ('_name', '_name_original', '_geometry', '_parent',
+                 '_type', '_boundary_condition', '_properties')
+
+    def __init__(self, name, geometry, type=None, boundary_condition=None):
+        """A single planar aperture in a face.
+
+        Args:
+            name: Aperture name. Must be < 100 characters.
+            geometry: A ladybug-geometry Face3D.
+            type: Aperture type. Default: Window
+            boundary_condition: Boundary condition object (Outdoors, Surface).
+                Default: Outdoors.
+        """
+        # process the name
+        self._name = valid_string(name, 'honeybee aperture name')
+        self._name_original = name
+
+        # process the geometry
+        assert isinstance(geometry, Face3D), \
+            'Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
+        self._geometry = geometry
+        self._parent = None  # _parent will be set when the Aperture is added to a Face
+
+        # process the type and boundary condition
+        self.type = type or aperture_types.window
+        self.boundary_condition = boundary_condition or boundary_conditions.outdoors
+
+        # initialize properties for extensions
+        self._properties = ApertureProperties(self)
+
+    @classmethod
+    def from_vertices(cls, name, vertices, type=None, boundary_condition=None):
+        """Create an Aperture from vertices with each vertex as an iterable of 3 floats.
+
+        Args:
+            name: Aperture name. Must be < 100 characters.
+            vertices: A flattened list of 3 or more vertices as (x, y, z).
+            type: Aperture type. Default: Window
+            boundary_condition: Boundary condition object (eg. Outdoors, Surface).
+                Default: Outdoors.
+        """
+        geometry = Face3D(tuple(Point3D(*v) for v in vertices))
+        return cls(name, geometry, type, boundary_condition)
+
+    @property
+    def name(self):
+        """The aperture name (including only legal characters)."""
+        return self._name
+
+    @property
+    def name_original(self):
+        """Original input name by user.
+
+        If there are no illegal characters in name then name and name_original will
+        be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
+        Invalid characters are automatically removed from the original name for
+        compatability with simulation engines.
+        """
+        return self._name_original
+
+    @property
+    def geometry(self):
+        """A ladybug_geometry Face3D object representing the aperture."""
+        return self._geometry
+
+    @property
+    def vertices(self):
+        """List of vertices for the aperture (in counter-clockwise order)."""
+        return self._geometry.vertices
+
+    @property
+    def upper_left_vertices(self):
+        """List of vertices starting from the upper-left corner.
+
+        This property should be used when exporting to EnergyPlus / OpenStudio.
+        """
+        return self._geometry.upper_left_counter_clockwise_vertices
+
+    @property
+    def triangulated_mesh3d(self):
+        """A ladybug_geometry Mesh3D of the aperture geometry composed of triangles.
+
+        In EnergyPlus / OpenStudio workflows, this property is used to subdivide
+        the aperture when it has more than 4 vertices. This is necessary since
+        EnergyPlus cannot accept sub-faces with more than 4 vertices.
+        """
+        return self._geometry.triangulated_mesh3d
+
+    @property
+    def normal(self):
+        """A ladybug_geometry Vector3D for the direction the aperture is pointing.
+        """
+        return self._geometry.normal
+
+    @property
+    def center(self):
+        """A ladybug_geometry Point3D for the center of the aperture.
+
+        Note that this is the center of the bounding rectangle around this geometry
+        and not the area centroid.
+        """
+        return self._geometry.center
+
+    @property
+    def area(self):
+        """The area of the aperture."""
+        return self._geometry.area
+
+    @property
+    def perimeter(self):
+        """The perimeter of the aperture."""
+        return self._geometry.perimeter
+
+    @property
+    def type(self):
+        """Object for Type of Aperture (ie. Window)."""
+        return self._type
+
+    @type.setter
+    def type(self, value):
+        assert value in self.TYPES, '{} is not a valid face type.'.format(value)
+        self._type = value
+
+    @property
+    def boundary_condition(self):
+        """Boundary condition of this aperture."""
+        return self._boundary_condition
+
+    @boundary_condition.setter
+    def boundary_condition(self, value):
+        assert isinstance(value, (Outdoors, Surface)), \
+            'Aperture only supports Outdoor or Surface boundary condition. ' \
+            'Got {}'.format(type(value))
+        self._boundary_condition = value
+
+    @property
+    def parent(self):
+        """Parent Face if assigned. None if not assigned."""
+        return self._parent
+
+    @property
+    def has_parent(self):
+        """Boolean noting whether this Aperture has a parent Face."""
+        return self._parent is not None
+
+    def set_adjacency(self, other_aperture):
+        """Set this aperture to be adjacent to another.
+
+        Note that this method does not verify whether the other_aperture geometry is
+        co-planar or compatible with this one so it is recommended that a test
+        be performed before using this method in order to verify these criteria.
+        The Face3D.is_centered_adjacent() or the Face3D.is_geometrically_equivalent()
+        methods are both suitable for this purpose.
+
+        Args:
+            other_aperture: Another Aperture object to be set adjacent to this one.
+        """
+        assert isinstance(other_aperture, Aperture), \
+            'Expected Aperture. Got {}.'.format(type(other_aperture))
+        self.boundary_condition = Surface(other_aperture)
+        other_aperture.boundary_condition = Surface(self)
+
+    def overhang(self, depth, angle=0, indoor=False, tolerance=0):
+        """Get a single overhang for this Aperture.
+
+        Args:
+            depth: A number for the overhang depth.
+            angle: A number for the for an angle to rotate the overhang in degrees.
+                Default is 0 for no rotation.
+            indoor: Boolean for whether the overhang should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to return None if the overhang has a length less
+                than the tolerance. Default is 0, which will always yeild an overhang.
+
+        Returns:
+            overhang: A Shade object for the Aperture overhang. You may want to run
+                the check_non_zero() method on the resulting Shade to verify
+                the geometry is subtantial when the Aperture does not have a flat top.
+        """
+        overhang = self.louvers_by_number(
+            1, depth, angle=angle, indoor=indoor, tolerance=tolerance)
+        return overhang[0] if len(overhang) != 0 else None
+
+    def right_fin(self, depth, angle=0, indoor=False, tolerance=0):
+        """Get a single vertical fin on the right side of this Aperture.
+
+        Args:
+            depth: A number for the fin depth.
+            angle: A number for the for an angle to rotate the fin in degrees.
+                Default is 0 for no rotation.
+            indoor: Boolean for whether the fin should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to return None if the fin has a length less
+                than the tolerance. Default is 0, which will always yeild a fin.
+
+        Returns:
+            fin: A Shade object for the Aperture fin. You may want to run
+                the check_non_zero() method on the resulting Shade to verify
+                the geometry is subtantial when the Aperture does not have a
+                flat right side.
+        """
+        fin = self.louvers_by_number(
+            1, depth, angle=angle, contour_vector=Vector3D(1, 0, 0),
+            indoor=indoor, tolerance=tolerance)
+        return fin[0] if len(fin) != 0 else None
+
+    def left_fin(self, depth, angle=0, indoor=False, tolerance=0):
+        """Get a single vertical fin on the left side of this Aperture.
+
+        Args:
+            depth: A number for the fin depth.
+            angle: A number for the for an angle to rotate the fin in degrees.
+                Default is 0 for no rotation.
+            indoor: Boolean for whether the fin should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to return None if the fin has a length less
+                than the tolerance. Default is 0, which will always yeild a fin.
+
+        Returns:
+            fin: A Shade object for the Aperture fin. You may want to run
+                the check_non_zero() method on the resulting Shade to verify
+                the geometry is subtantial when the Aperture does not have a
+                flat right side.
+        """
+        fin = self.louvers_by_number(
+            1, depth, angle=angle, contour_vector=Vector3D(1, 0, 0),
+            flip_start_side=True, indoor=indoor, tolerance=tolerance)
+        return fin[0] if len(fin) != 0 else None
+
+    def extruded_border(self, depth, indoor=False):
+        """Get a list of Shade objects from the extruded border of this aperture.
+
+        Args:
+            depth: A number for the extrusion depth.
+            indoor: Boolean for whether the extrusion should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+
+        Returns:
+            extrusion: A list of Shade objects for the extruded border.
+        """
+        extru_vec = self.normal if indoor is False else self.normal.reverse()
+        extru_vec = extru_vec * depth
+        extrusion = []
+        shd_count = 0
+        for seg in self.geometry.boundary_segments:
+            shade_geo = Face3D.from_extrusion(seg, extru_vec)
+            extrusion.append(
+                Shade('{}_Shd{}'.format(self.name_original, shd_count), shade_geo))
+            shd_count += 1
+        if self.geometry.has_holes:
+            for hole in self.geometry.hole_segments:
+                for seg in hole:
+                    shade_geo = Face3D.from_extrusion(seg, extru_vec)
+                    extrusion.append(
+                        Shade('{}_Shd{}'.format(self.name_original, shd_count),
+                              shade_geo))
+                    shd_count += 1
+        return extrusion
+
+    def louvers_by_number(self, louver_count, depth, offset=0, angle=0,
+                          contour_vector=Vector3D(0, 0, 1), flip_start_side=False,
+                          indoor=False, tolerance=0):
+        """Get a list of louvered Shade objects covering this Aperture.
+
+        Args:
+            louver_count: A positive integer for the number of louvers to generate.
+            depth: A number for the depth to extrude the louvers.
+            offset: A number for the distance to louvers from this aperture.
+                Default is 0 for no offset.
+            angle: A number for the for an angle to rotate the louvers in degrees.
+                Default is 0 for no rotation.
+            contour_vector: A Vector3D for the direction along which contours
+                are generated. Default is Z-Axis, which generates horizontal louvers.
+            flip_start_side: Boolean to note whether the side the louvers start from
+                should be flipped. Default is False to have louvers on top or right.
+                Setting to True will start contours on the bottom or left.
+            indoor: Boolean for whether louvers should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to remove any louvers with a length less
+                than the tolerance. Default is 0, which will include all louvers
+                no matter how small.
+
+        Returns:
+            louvers: A list of Shade objects that cover the Aperture.
+        """
+        assert louver_count > 0, 'louver_count must be greater than 0.'
+        angle = math.radians(angle)
+        louvers = []
+        ap_geo = self.geometry if indoor is False else self.geometry.flip()
+        shade_faces = ap_geo.countour_fins_by_number(
+            louver_count, depth, offset, angle,
+            contour_vector, flip_start_side, tolerance)
+        for i, shade_geo in enumerate(shade_faces):
+            louvers.append(Shade('{}_Shd{}'.format(self.name_original, i), shade_geo))
+        return louvers
+
+    def louvers_by_distance_between(self, distance, depth, offset=0, angle=0,
+                                    contour_vector=Vector3D(0, 0, 1),
+                                    flip_start_side=False, indoor=False, tolerance=0):
+        """Get a list of louvered Shade objects covering this Aperture.
+
+        Args:
+            distance: A number for the approximate distance between each louver.
+            depth: A number for the depth to extrude the louvers.
+            offset: A number for the distance to louvers from this aperture.
+                Default is 0 for no offset.
+            angle: A number for the for an angle to rotate the louvers in degrees.
+                Default is 0 for no rotation.
+            contour_vector: A Vector3D for the direction along which contours
+                are generated. Default is Z-Axis, which generates horizontal louvers.
+            flip_start_side: Boolean to note whether the side the louvers start from
+                should be flipped. Default is False to have contours on top or right.
+                Setting to True will start contours on the bottom or left.
+            indoor: Boolean for whether louvers should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to remove any louvers with a length less
+                than the tolerance. Default is 0, which will include all louvers
+                no matter how small.
+
+        Returns:
+            louvers: A list of Shade objects that cover the Aperture.
+        """
+        angle = math.radians(angle)
+        louvers = []
+        ap_geo = self.geometry if indoor is False else self.geometry.flip()
+        shade_faces = ap_geo.countour_fins_by_distance_between(
+            distance, depth, offset, angle,
+            contour_vector, flip_start_side, tolerance)
+        for i, shade_geo in enumerate(shade_faces):
+            louvers.append(Shade('{}_Shd{}'.format(self.name_original, i), shade_geo))
+        return louvers
+
+    def move(self, moving_vec):
+        """Move this Aperture along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the face.
+        """
+        self._geometry = self.geometry.move(moving_vec)
+
+    def rotate(self, axis, angle, origin):
+        """Rotate this Aperture by a certain angle around an axis and origin.
+
+        Args:
+            axis: A ladybug_geometry Vector3D axis representing the axis of rotation.
+            angle: An angle for rotation in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this Aperture counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
+
+    def reflect(self, plane):
+        """Reflect this Aperture across a plane with the input normal vector and origin.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        assert isinstance(plane, Plane), \
+            'Expected ladybug_geometry Plane. Got {}.'.format(type(plane))
+        self._geometry = self.geometry.reflect(plane.n, plane.o)
+
+    def scale(self, factor, origin=None):
+        """Scale this Aperture by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self._geometry = self.geometry.scale(factor, origin)
+
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check whether all of the Aperture's vertices lie within the same plane.
+
+        Args:
+            tolerance: The minimum distance between a given vertex and a the
+                object's's plane at which the vertex is said to lie in the plane.
+            raise_exception: Boolean to note whether an ValueError should be
+                raised if a vertex does not lie within the object's plane.
+        """
+        try:
+            return self.geometry.validate_planarity(tolerance, raise_exception)
+        except ValueError as e:
+            raise ValueError('Aperture "{}" is not planar.\n{}'.format(
+                self.name_original, e))
+
+    def check_self_intersecting(self, raise_exception=True):
+        """Check whether the edges of the Aperture intersect one another (like a bowtwie)
+
+        Args:
+            raise_exception: If True, a ValueError will be raised if the object
+                intersects with itself. Default: True.
+        """
+        if self.geometry.is_self_intersecting:
+            if raise_exception:
+                raise ValueError('Aperture "{}" has self-intersecting edges.'.format(
+                    self.name_original))
+            return False
+        return True
+
+    def check_non_zero(self, tolerance=0.0001, raise_exception=True):
+        """Check whether the area of the Aperture is above a certain "zero" tolerance.
+
+        Args:
+            tolerance: The minimum acceptable area of the object. Default is 0.0001,
+                which is equal to 1 cm2 when model units are meters. This is just
+                above the smalest size that OpenStudio will accept.
+            raise_exception: If True, a ValueError will be raised if the object
+                area is below the tolerance. Default: True.
+        """
+        if self.area < tolerance:
+            if raise_exception:
+                raise ValueError(
+                    'Aperture "{}" geometry is too small. Area must be at least {}. '
+                    'Got {}.'.format(self.name_original, tolerance, self.area))
+            return False
+        return True
+
+    @property
+    def properties(self):
+        """Aperture properties, including Radiance, Energy and other properties."""
+        return self._properties
+
+    @property
+    def to(self):
+        """Aperture writer object.
+
+        Use this method to access Writer class to write the aperture in other formats.
+
+        Usage:
+            aperture.to.idf(aperture) -> idf string.
+            aperture.to.radiance(aperture) -> Radiance string.
+        """
+        raise NotImplementedError('Aperture does not yet support writing to files.')
+        return writer
+
+    def to_dict(self, abridged=False, included_prop=None):
+        """Return Aperture as a dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            included_prop: List of properties to filter keys that must be included in
+                output dictionary. For example ['energy'] will include 'energy' key if
+                available in properties to_dict. By default all the keys will be
+                included. To exclude all the keys from plugins use an empty list.
+        """
+        base = {
+            'type': self.__class__.__name__,
+            'name': self.name,
+            'name_original': self.name_original,
+            'geometry': self._geometry.to_dict(),
+            'aperture_type': self.type.to_dict(),
+            'properties': self.properties.to_dict(abridged, included_prop)
+        }
+        if 'energy' in base['properties']:
+            base['boundary_condition'] = self.boundary_condition.to_dict(full=True)
+        else:
+            base['boundary_condition'] = self.boundary_condition.to_dict(full=False)
+        if self.parent:
+            base['parent'] = self.parent.name
+        else:
+            base['parent'] = None
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __copy__(self):
+        new_ap = Aperture(self.name_original, self.geometry, self.type,
+                          self.boundary_condition)
+        new_ap._properties.duplicate_extension_attr(self._properties)
+        return new_ap
+
+    def __repr__(self):
+        return 'Aperture: %s' % self.name_original

--- a/honeybee/aperturetype.py
+++ b/honeybee/aperturetype.py
@@ -1,0 +1,51 @@
+# coding=utf-8
+"""Aperture Types."""
+
+
+class _ApertureType(object):
+    __slots__ = ()
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def to_dict(self):
+        """ApertureType as a dictionary."""
+        ap_type_dict = {
+            'type': self.name}
+        return ap_type_dict
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.name
+
+
+class Window(_ApertureType):
+    """Type for static apertures that are not intended to be opened."""
+    __slots__ = ()
+    pass
+
+
+class _Types(object):
+    """Aperture types."""
+
+    def __init__(self):
+        self._window = Window()
+
+    @property
+    def window(self):
+        return self._window
+
+    def __contains__(self, value):
+        return isinstance(value, _ApertureType)
+
+
+aperture_types = _Types()

--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -1,125 +1,163 @@
-"""Face Boundary Condition."""
-import weakref
+"""Boundary Condition for Face, Aperture, Door."""
+from .typing import float_in_range
 
 
 class _BoundaryCondition(object):
+    """Base boundary condition class."""
 
     __slots__ = (
-        '_sun_exposure', '_wind_exposure', '_boundary_condition_object', '_view_factor'
-    )
+        '_sun_exposure', '_wind_exposure', '_view_factor')
 
-    def __init__(self):
-        self.sun_exposure = False
-        self.wind_exposure = False
-        self.boundary_condition_object = None
-        self.view_factor = 'autocalculate'
+    def __init__(self, sun_exposure=False, wind_exposure=False,
+                 view_factor='autocalculate'):
+        """Initialize Boundary condition.
+
+        Args:
+            sun_exposure: A boolean noting whether the boundary is exposed to sun.
+                Default: False.
+            wind_exposure: A boolean noting whether the boundary is exposed to wind.
+                Default: False.
+            view_factor: A number between 0 and 1 for the view factor to the ground.
+                This input can also be the word 'autocalculate' to have the view
+                factor automatically calculated.  Default: 'autocalculate'.
+        """
+        assert isinstance(sun_exposure, bool), \
+            'Input sun_exposure must be a Boolean. Got {}.'.format(type(sun_exposure))
+        self._sun_exposure = sun_exposure
+        assert isinstance(wind_exposure, bool), \
+            'Input wind_exposure must be a Boolean. Got {}.'.format(type(wind_exposure))
+        self._wind_exposure = wind_exposure
+        if view_factor == 'autocalculate':
+            self._view_factor = view_factor
+        else:
+            self._view_factor = float_in_range(
+                view_factor, 0.0, 1.0, 'view factor to ground')
 
     @property
     def name(self):
+        """Name of the boundary condition (ie. 'Outdoors', 'Ground')."""
         return self.__class__.__name__
 
     @property
     def sun_exposure(self):
+        """A boolean noting whether the boundary is exposed to sun."""
         return self._sun_exposure
-
-    @sun_exposure.setter
-    def sun_exposure(self, value):
-        assert isinstance(value, bool), \
-            'Input value must be a Boolean not {}.'.format(type(value))
-        self._sun_exposure = value
 
     @property
     def wind_exposure(self):
+        """A boolean noting whether the boundary is exposed to wind."""
         return self._wind_exposure
-
-    @wind_exposure.setter
-    def wind_exposure(self, value):
-        assert isinstance(value, bool), \
-            'Input value must be a Boolean not {}.'.format(type(value))
-        self._wind_exposure = value
-
-    @property
-    def boundary_condition_object(self):
-        return self._boundary_condition_object
-
-    @boundary_condition_object.setter
-    def boundary_condition_object(self, bco):
-        self._boundary_condition_object = bco
 
     @property
     def view_factor(self):
+        """The view factor to the ground as a number or 'autocalculate'."""
         return self._view_factor
-
-    @view_factor.setter
-    def view_factor(self, vf):
-        if vf == 'autocalculate':
-            self._view_factor = vf
-        else:
-            self._view_factor = float(vf)
 
     @property
     def sun_exposure_idf(self):
+        """Text string for sun exposure, which is write-able into an IDF."""
         return 'NoSun' if not self.wind_exposure else 'SunExposed'
 
     @property
     def wind_exposure_idf(self):
+        """Text string for wind exposure, which is write-able into an IDF."""
         return 'NoWind' if not self.wind_exposure else 'WindExposed'
-
-    @property
-    def boundary_condition_object_idf(self):
-        return '' if not self.boundary_condition_object else \
-            self.boundary_condition_object.name
 
     def to_dict(self, full=False):
         """Boundary condition as a dictionary.
-        
-        args:
-            full: Set to True to get the full dictionary which includes energy simulation
-            specific keys such as sun_exposure, wind_exposure and view_factor. Default is
-            set to False.
-        
-        returns:
-            A dictionary.
+
+        Args:
+            full: Set to True to get the full dictionary which includes energy
+                simulation specific keys such as sun_exposure, wind_exposure and
+                view_factor. Default: False.
         """
         if full:
-            return {
-                'name': self.name,
-                'bc_object': self.boundary_condition_object_idf,
+            bc_dict = {
+                'type': self.name,
                 'sun_exposure': self.sun_exposure_idf,
                 'wind_exposure': self.wind_exposure_idf,
                 'view_factor': self.view_factor
             }
         else:
-            return {
-                'name': self.name,
-                'bc_object': self.boundary_condition_object_idf
+            bc_dict = {
+                'type': self.name,
             }
+        if hasattr(self, 'boundary_condition_object'):  # Surface boundary condition
+            bc_dict['bc_object'] = self.boundary_condition_object
+        return bc_dict
+
+    def ToString(self):
+        return self.__repr__()
 
     def __repr__(self):
         return self.name
 
 
 class Surface(_BoundaryCondition):
+    """Bondary condition when an object is adjacent to another object."""
 
-    __slots__ = ()
+    __slots__ = ('_boundary_condition_objects',)
 
-    def __init__(self, other_object=None):
+    def __init__(self, other_object):
+        """Initialize Surface boundary condition.
+
+        Args:
+            other_object: Another object (Face, Aperture, Door) of the same type
+                that this boundary condition is assigned.  This other_object will be
+                set as the adjacent object in this boundary condition.
+        """
         _BoundaryCondition.__init__(self)
-        if other_object:
-            self.boundary_condition_object = weakref.proxy(other_object)
+        self._boundary_condition_objects = []
+        if other_object is not None:
+            self._boundary_condition_objects.append(other_object.name)
+            if other_object.has_parent:
+                self._boundary_condition_objects.append(other_object.parent.name)
+                if other_object.parent.has_parent:
+                    self._boundary_condition_objects.append(
+                        other_object.parent.parent.name)
+
+    @property
+    def boundary_condition_objects(self):
+        """A tuple of up to 3 object names that are adjacent to this one.
+
+        The first object is always the one that is immediately adjacet and is of
+        the same object type (Face, Aperture, Door).
+        When this boundary condition is applied to a Face, the second object in the
+        tuple will be the parent Room of the adjacent object.
+        When the boundary condition is allplied to a sub-face (Door or Aperture),
+        the second object will be the parent Face of the sub-face and the third
+        object will be the parent Room of the adjacent sub-face.
+        """
+        return tuple(self._boundary_condition_objects)
+
+    @property
+    def boundary_condition_object(self):
+        """The name of the object adjacent to this one."""
+        return self._boundary_condition_objects[0]
 
 
 class Outdoors(_BoundaryCondition):
-
+    """Outdoor boundary condition."""
     __slots__ = ()
 
-    def __init__(self):
-        _BoundaryCondition.__init__(self)
-        self.wind_exposure = True
-        self.sun_exposure = True
+    def __init__(self, sun_exposure=True, wind_exposure=True,
+                 view_factor='autocalculate'):
+        """Initialize Outdoors boundary condition.
+
+        Args:
+            sun_exposure: A boolean noting whether the boundary is exposed to sun.
+                Default: True.
+            wind_exposure: A boolean noting whether the boundary is exposed to wind.
+                Default: True.
+            view_factor: A number between 0 and 1 for the view factor to the ground.
+                This input can also be the word 'autocalculate' to have the view
+                factor automatically calculated.  Default: 'autocalculate'.
+        """
+        _BoundaryCondition.__init__(self, sun_exposure, wind_exposure, view_factor)
 
 
 class Ground(_BoundaryCondition):
+    """Ground boundary condition."""
     __slots__ = ()
     pass
 
@@ -139,7 +177,7 @@ class _BoundaryConditions(object):
     def ground(self):
         return self._ground
 
-    def surface(self, other_object=None):
+    def surface(self, other_object):
         return Surface(other_object)
 
     def __contains__(self, value):
@@ -147,3 +185,25 @@ class _BoundaryConditions(object):
 
 
 boundary_conditions = _BoundaryConditions()
+
+
+def get_bc_from_position(positions, ground_depth=0):
+    """Return a boundary condition based on the relationship to a gound plane.
+
+    Positions that are entirely at or below the ground_depth will get a Ground
+    boundary condition. If there are any positions above the ground_depth, an
+    Outdoors boundary condition will be returned.
+
+    args:
+        positions: A list of ladybug_geometry Point3D objects represeting the
+            vertices of an object.
+        ground_depth: The Z value above which positions are considered Outdoors
+            instead of Ground.
+
+    Returns:
+        Face type instance.
+    """
+    for position in positions:
+        if position.z > ground_depth:
+            return boundary_conditions.outdoors
+    return boundary_conditions.ground

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -1,0 +1,340 @@
+# coding: utf-8
+"""Honeybee Door."""
+from .properties import DoorProperties
+from .boundarycondition import boundary_conditions, Outdoors, Surface
+from .typing import valid_string
+import honeybee.writer as writer
+
+from ladybug_geometry.geometry3d.pointvector import Point3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.face import Face3D
+
+import math
+
+
+class Door(object):
+    """A single planar door in a honeybee Face.
+
+    Properties:
+        name
+        name_original
+        geometry
+        vertices
+        upper_left_vertices
+        triangulated_mesh3d
+        normal
+        center
+        area
+        perimeter
+        boundary_condition
+        parent
+        has_parent
+    """
+    __slots__ = ('_name', '_name_original', '_geometry', '_parent',
+                 '_boundary_condition', '_properties')
+
+    def __init__(self, name, geometry, boundary_condition=None):
+        """A single planar door in a honeybee Face.
+
+        Args:
+            name: Door name. Must be < 100 characters.
+            geometry: A ladybug-geometry Face3D.
+            boundary_condition: Boundary condition object (Outdoors, Surface, etc.).
+                Default: Outdoors.
+        """
+        # process the name
+        self._name = valid_string(name, 'honeybee door name')
+        self._name_original = name
+
+        # process the geometry
+        assert isinstance(geometry, Face3D), \
+            'Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
+        self._geometry = geometry
+        self._parent = None  # _parent will be set when the Face is added to a Face
+
+        # process the boundary condition
+        self.boundary_condition = boundary_condition or boundary_conditions.outdoors
+
+        # initialize properties for extensions
+        self._properties = DoorProperties(self)
+
+    @classmethod
+    def from_vertices(cls, name, vertices, boundary_condition=None):
+        """Create a Door from vertices with each vertex as an iterable of 3 floats.
+
+        Args:
+            name: Door name. Must be < 100 characters.
+            vertices: A flattened list of 3 or more vertices as (x, y, z).
+            boundary_condition: Boundary condition object (eg. Outdoors, Surface).
+                Default: Outdoors.
+        """
+        geometry = Face3D(tuple(Point3D(*v) for v in vertices))
+        return cls(name, geometry, boundary_condition)
+
+    @property
+    def name(self):
+        """The door name (including only legal characters)."""
+        return self._name
+
+    @property
+    def name_original(self):
+        """Original input name by user.
+
+        If there are no illegal characters in name then name and name_original will
+        be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
+        Invalid characters are automatically removed from the original name for
+        compatability with simulation engines.
+        """
+        return self._name_original
+
+    @property
+    def geometry(self):
+        """A ladybug_geometry Face3D object representing the door."""
+        return self._geometry
+
+    @property
+    def vertices(self):
+        """List of vertices for the door (in counter-clockwise order)."""
+        return self._geometry.vertices
+
+    @property
+    def upper_left_vertices(self):
+        """List of vertices starting from the upper-left corner.
+
+        This property should be used when exporting to EnergyPlus / OpenStudio.
+        """
+        return self._geometry.upper_left_counter_clockwise_vertices
+
+    @property
+    def triangulated_mesh3d(self):
+        """A ladybug_geometry Mesh3D of the door geometry composed of triangles.
+
+        In EnergyPlus / OpenStudio workflows, this property is used to subdivide
+        the door when it has more than 4 vertices. This is necessary since
+        EnergyPlus cannot accept sub-faces with more than 4 vertices.
+        """
+        return self._geometry.triangulated_mesh3d
+
+    @property
+    def normal(self):
+        """A ladybug_geometry Vector3D for the direction the door is pointing.
+        """
+        return self._geometry.normal
+
+    @property
+    def center(self):
+        """A ladybug_geometry Point3D for the center of the door.
+
+        Note that this is the center of the bounding rectangle around this geometry
+        and not the area centroid.
+        """
+        return self._geometry.center
+
+    @property
+    def area(self):
+        """The area of the door."""
+        return self._geometry.area
+
+    @property
+    def perimeter(self):
+        """The perimeter of the door."""
+        return self._geometry.perimeter
+
+    @property
+    def boundary_condition(self):
+        """Boundary condition of this door."""
+        return self._boundary_condition
+
+    @boundary_condition.setter
+    def boundary_condition(self, value):
+        assert isinstance(value, (Outdoors, Surface)), \
+            'Door boundary condition must be Outdoors or Surface. ' \
+            'Got {}'.format(type(value))
+        self._boundary_condition = value
+
+    @property
+    def parent(self):
+        """Parent Face if assigned. None if not assigned."""
+        return self._parent
+
+    @property
+    def has_parent(self):
+        """Boolean noting whether this Door has a parent Face."""
+        return self._parent is not None
+
+    def set_adjacency(self, other_door):
+        """Set this door to be adjacent to another (and vice versa).
+
+        Note that this method does not verify whether the other_door geometry is
+        co-planar or compatible with this one so it is recommended that a test
+        be performed before using this method in order to verify these criteria.
+        The Face3D.is_centered_adjacent() or the Face3D.is_geometrically_equivalent()
+        methods are both suitable for this purpose.
+
+        Args:
+            other_aperture: Another Aperture object to be set adjacent to this one.
+        """
+        assert isinstance(other_door, Door), \
+            'Expected Door. Got {}.'.format(type(other_door))
+        self.boundary_condition = Surface(other_door)
+        other_door.boundary_condition = Surface(self)
+
+    def move(self, moving_vec):
+        """Move this Door along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the face.
+        """
+        self._geometry = self.geometry.move(moving_vec)
+
+    def rotate(self, axis, angle, origin):
+        """Rotate this Door by a certain angle around an axis and origin.
+
+        Args:
+            axis: A ladybug_geometry Vector3D axis representing the axis of rotation.
+            angle: An angle for rotation in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this Door counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
+
+    def reflect(self, plane):
+        """Reflect this Door across a plane with the input normal vector and origin.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        assert isinstance(plane, Plane), \
+            'Expected ladybug_geometry Plane. Got {}.'.format(type(plane))
+        self._geometry = self.geometry.reflect(plane.n, plane.o)
+
+    def scale(self, factor, origin=None):
+        """Scale this Door by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self._geometry = self.geometry.scale(factor, origin)
+
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check whether all of the Door's vertices lie within the same plane.
+
+        Args:
+            tolerance: The minimum distance between a given vertex and a the
+                object's's plane at which the vertex is said to lie in the plane.
+            raise_exception: Boolean to note whether an ValueError should be
+                raised if a vertex does not lie within the object's plane.
+        """
+        try:
+            return self.geometry.validate_planarity(tolerance, raise_exception)
+        except ValueError as e:
+            raise ValueError('Door "{}" is not planar.\n{}'.format(
+                self.name_original, e))
+
+    def check_self_intersecting(self, raise_exception=True):
+        """Check whether the edges of the Door intersect one another (like a bowtwie).
+
+        Args:
+            raise_exception: If True, a ValueError will be raised if the object
+                intersects with itself. Default: True.
+        """
+        if self.geometry.is_self_intersecting:
+            if raise_exception:
+                raise ValueError('Door "{}" has self-intersecting edges.'.format(
+                    self.name_original))
+            return False
+        return True
+
+    def check_non_zero(self, tolerance=0.0001, raise_exception=True):
+        """Check whether the area of the Door is above a certain "zero" tolerance.
+
+        Args:
+            tolerance: The minimum acceptable area of the object. Default is 0.0001,
+                which is equal to 1 cm2 when model units are meters. This is just
+                above the smalest size that OpenStudio will accept.
+            raise_exception: If True, a ValueError will be raised if the object
+                area is below the tolerance. Default: True.
+        """
+        if self.area < tolerance:
+            if raise_exception:
+                raise ValueError(
+                    'Door "{}" geometry is too small. Area must be at least {}. '
+                    'Got {}.'.format(self.name_original, tolerance, self.area))
+            return False
+        return True
+
+    @property
+    def properties(self):
+        """Door properties, including Radiance, Energy and other properties."""
+        return self._properties
+
+    @property
+    def to(self):
+        """Door writer object.
+
+        Use this method to access Writer class to write the door in different formats.
+
+        Usage:
+            door.to.idf(door) -> idf string.
+            door.to.radiance(door) -> Radiance string.
+        """
+        raise NotImplementedError('Door does not yet support writing to files.')
+        return writer
+
+    def to_dict(self, abridged=False, included_prop=None):
+        """Return Door as a dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            included_prop: List of properties to filter keys that must be included in
+                output dictionary. For example ['energy'] will include 'energy' key if
+                available in properties to_dict. By default all the keys will be
+                included. To exclude all the keys from plugins use an empty list.
+        """
+        base = {
+            'type': self.__class__.__name__,
+            'name': self.name,
+            'name_original': self.name_original,
+            'geometry': self._geometry.to_dict(),
+            'properties': self.properties.to_dict(abridged, included_prop)
+        }
+        if 'energy' in base['properties']:
+            base['boundary_condition'] = self.boundary_condition.to_dict(full=True)
+        else:
+            base['boundary_condition'] = self.boundary_condition.to_dict(full=False)
+        if self.parent:
+            base['parent'] = self.parent.name
+        else:
+            base['parent'] = None
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __copy__(self):
+        new_door = Door(self.name_original, self.geometry, self.boundary_condition)
+        new_door._properties.duplicate_extension_attr(self._properties)
+        return new_door
+
+    def __repr__(self):
+        return 'Door: %s' % self.name_original

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -1,158 +1,894 @@
 # coding: utf-8
 """Honeybee Face."""
-from .properties import Properties
-from .facetype import get_type_from_normal
+from .properties import FaceProperties
+from .facetype import face_types, get_type_from_normal, AirWall
+from .boundarycondition import get_bc_from_position, _BoundaryCondition, \
+    Outdoors, Surface
+from .shade import Shade
+from .aperture import Aperture
+from .door import Door
 from .typing import valid_string
 import honeybee.writer as writer
-from ladybug_geometry.geometry3d.face import Face3D
-from ladybug_geometry.geometry3d.pointvector import Point3D
 
-import re
-import weakref
+from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.face import Face3D
+
+import math
 
 
 class Face(object):
-    """A single planar face."""
-    _name_descr = 'honeybee face name'
+    """A single planar face.
 
-    def __init__(self, name, geometry, face_type=None, boundary_condition=None):
+    Properties:
+        name
+        name_original
+        geometry
+        punched_geometry
+        vertices
+        punched_vertices
+        upper_left_vertices
+        normal
+        center
+        area
+        perimeter
+        type
+        boundary_condition
+        apertures
+        doors
+        parent
+        has_parent
+    """
+    TYPES = face_types
+    __slots__ = ('_name', '_name_original', '_geometry', '_parent', '_punched_geometry',
+                 '_apertures', '_doors', '_type', '_boundary_condition', '_properties')
+
+    def __init__(self, name, geometry, type=None, boundary_condition=None):
         """A single planar face.
+
+        Args:
+            name: Face name. Must be < 100 characters.
+            geometry: A ladybug-geometry Face3D.
+            type: Face type. Default varies depending on the direction that
+                the Face geometry is points.
+                RoofCeiling = pointing upward within 30 degrees
+                Wall = oriented vertically within +/- 60 degrees
+                Floor = pointing downward within 30 degrees
+            boundary_condition: Face boundary condition (Outdoors, Ground, etc.)
+                Default is Outdoors unless the center of the input geometry lies
+                below the XY plane, in which case it will be set to Ground.
+        """
+        # process the name
+        self._name = valid_string(name, 'honeybee face name')
+        self._name_original = name
+
+        # process the geometry
+        assert isinstance(geometry, Face3D), \
+            'Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
+        self._geometry = geometry
+        self._parent = None  # _parent will be set when the Face is added to a Room
+        # initialize with no apertures/doors (they can be assigned later)
+        self._punched_geometry = None
+        self._apertures = []
+        self._doors = []
+
+        # set face type based on normal if not provided
+        self.type = type or get_type_from_normal(geometry.normal)
+
+        # set boundary condition by the relation to a zero ground plane if not provided
+        self.boundary_condition = boundary_condition or \
+            get_bc_from_position(geometry.boundary)
+
+        # initialize properties for extensions
+        self._properties = FaceProperties(self)
+
+    @classmethod
+    def from_vertices(cls, name, vertices, type=None, boundary_condition=None):
+        """Create a Face from vertices with each vertex as an iterable of 3 floats.
+
+        Note that this method is not recommended for a face with one or more holes
+        since the distinction between hole vertices and boundary vertices cannot
+        be derived from a single list of vertices.
+
         Args:
             name: Face name.
-            geometry: A ladybug-geometry Face3D.
-            face_type: Face type (e.g. wall, floor).
-            boundary_condition: Face boundary condition (Outdoors, Ground, etc.)
+            vertices: A flattened list of 3 or more vertices as (x, y, z).
+            type: Face type object (eg. Wall, Floor).
+            boundary_condition: Boundary condition object (eg. Outdoors, Surface)
         """
-        self.name = name
-        assert isinstance(geometry, Face3D), \
-            'Expected ladybug_geometry Face3D not {}'.format(type(geometry))
-        self._geometry = geometry
-        # _parent will be set when the Face is added to a Zone
-        # in case of aperture it will be added when aperture is added to a Face.
-        self._parent = None
-        # get face type based on normal if face_type is not provided
-        face_type = face_type or get_type_from_normal(geometry.normal)
-        self._properties = Properties(face_type, boundary_condition)
-        self._writer = writer
-        self._apertures = []
+        geometry = Face3D(tuple(Point3D(*v) for v in vertices))
+        return cls(name, geometry, type, boundary_condition)
 
     @property
     def name(self):
-        """Face name."""
+        """The face name (including only legal characters)."""
         return self._name
-
-    @name.setter
-    def name(self, value):
-        self._name = valid_string(value, self._name_descr)
-        self._name_original = value
 
     @property
     def name_original(self):
         """Original input name by user.
 
-        If there is no illegal characters in name then name and name_original will be the
-        same. Legal characters are ., A-Z, a-z, 0-9, _ and -. Invalid characters are
-        removed from the original name for compatability with simulation engines.
+        If there are no illegal characters in name then name and name_original will
+        be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
+        Invalid characters are automatically removed from the original name for
+        compatability with simulation engines.
         """
         return self._name_original
 
     @property
+    def geometry(self):
+        """A ladybug_geometry Face3D object representing the Face.
+
+        Note that this Face3D only represents the parent face and does not have any
+        holes cut in it for apertures or doors.
+        """
+        return self._geometry
+
+    @property
+    def punched_geometry(self):
+        """A ladybug_geometry Face3D object with holes cut in it for apertures and doors.
+        """
+        if self._punched_geometry is None:
+            _sub_faces = tuple(sub_f.geometry for sub_f in self._apertures + self._doors)
+            if _sub_faces != []:
+                self._punched_geometry = Face3D.from_punched_geometry(
+                    self._geometry, _sub_faces)
+            else:
+                self._punched_geometry = self._geometry
+        return self._punched_geometry
+
+    @property
     def vertices(self):
-        """List of vertices."""
+        """List of vertices for the face (in counter-clockwise order).
+
+        Note that these vertices only represent the outer boundary of the face
+        and do not account for holes cut in the face by apertures or doors.
+        """
         return self._geometry.vertices
 
     @property
-    def face_type(self):
-        """Face type."""
-        return self._properties.face_type
+    def punched_vertices(self):
+        """List of vertices with holes cut in it for apertures and doors.
 
-    @face_type.setter
-    def face_type(self, f_type):
-        self._properties.face_type = f_type
+        Note that some vertices will be repeated since the vertices effectively
+        trace out a single boundary around the whole shape, winding inward to cut
+        out the holes. This property should be used  when exporting to Radiance.
+        """
+        return self.punched_geometry.vertices
+
+    @property
+    def upper_left_vertices(self):
+        """List of vertices starting from the upper-left corner.
+
+        This property obeys the same rules as the vertices property but always starts
+        from the upper-left-most vertex.  This property should be used when exporting to
+        EnergyPlus / OpenStudio.
+        """
+        return self._geometry.upper_left_counter_clockwise_vertices
+
+    @property
+    def normal(self):
+        """A ladybug_geometry Vector3D for the direction in which the face is pointing.
+        """
+        return self._geometry.normal
+
+    @property
+    def center(self):
+        """A ladybug_geometry Point3D for the center of the face.
+
+        Note that this is the center of the bounding rectangle around this geometry
+        and not the area centroid.
+        """
+        return self._geometry.center
+
+    @property
+    def area(self):
+        """The area of the face."""
+        return self._geometry.area
+
+    @property
+    def perimeter(self):
+        """The perimeter of the face. This includes the length of holes in the face."""
+        return self._geometry.perimeter
+
+    @property
+    def type(self):
+        """Object for Type of Face (ie. Wall, Floor, Roof)."""
+        return self._type
+
+    @type.setter
+    def type(self, value):
+        assert value in self.TYPES, '{} is not a valid face type.'.format(value)
+        if self._apertures != [] or self._doors != []:
+            assert not isinstance(value, AirWall), \
+                '{} cannot be assigned to a Face with Apertures or Doors.'.format(value)
+        self._type = value
 
     @property
     def boundary_condition(self):
-        """Face type."""
-        return self._properties.boundary_condition
+        """Object for the Face Boundary Condition (ie. Outdoors, Surface, Ground)."""
+        return self._boundary_condition
 
     @boundary_condition.setter
-    def boundary_condition(self, bc):
-        self._properties.boundary_condition = bc
+    def boundary_condition(self, value):
+        assert isinstance(value, _BoundaryCondition), \
+            'Expected BoundaryCondition. Got {}'.format(type(value))
+        if self._apertures != [] or self._doors != []:
+            assert isinstance(value, (Outdoors, Surface)), \
+                '{} cannot be assigned to a Face with apertures or doors.'.format(value)
+        self._boundary_condition = value
 
     @property
     def apertures(self):
-        """List of apertures."""
-        return self._apertures
+        """List of apertures in this Face."""
+        return tuple(self._apertures)
+
+    @property
+    def doors(self):
+        """List of doors in this Face."""
+        return tuple(self._doors)
 
     @property
     def parent(self):
-        """Parent zone."""
+        """Parent Room if assigned. None if not assigned."""
         return self._parent
 
-    @classmethod
-    def from_vertices(cls, name, vertices, face_type=None, boundary_condition=None):
-        """Create a Face from vertices.
+    @property
+    def has_parent(self):
+        """Boolean noting whether this Face has a parent Room."""
+        return self._parent is not None
 
-        args:
-            name: Face name.
-            vertices: A flattened list of 3 or more vertices as (x, y, z).
-            face_type: Face type (e.g. wall, floor).
+    def horizontal_orientation(self, north_vector=Vector2D(0, 1)):
+        """A number between 0 and 360 for the orientation of the face in degrees.
+
+        0 = North, 90 = East, 180 = South, 270 = West
+
+        Args:
+            north_vector: A ladybug_geometry Vector2D for the north direction.
+                Default is the Y-axis (0, 1).
         """
-        geometry = Face3D([Point3D(*v) for v in vertices])
-        return cls(name, geometry, face_type, boundary_condition)
+        return math.degrees(
+            north_vector.angle_clockwise(Vector2D(self.normal.x, self.normal.y)))
+
+    def cardinal_direction(self, north_vector=Vector2D(0, 1)):
+        """Text description for the cardinal direction that the face is pointing.
+
+        Will be one of the following: ('North', 'East', 'South', 'West')
+
+        Args:
+            north_vector: A ladybug_geometry Vector2D for the north direction.
+                Default is the Y-axis (0, 1).
+        """
+        orient = self.horizontal_orientation(north_vector)
+        if orient <= 45 or orient > 315:
+            return 'North'
+        elif orient <= 135:
+            return 'East'
+        elif orient <= 225:
+            return 'South'
+        else:
+            return 'West'
+
+    def clear_sub_faces(self):
+        """Remove all apertures and doors from the face."""
+        self.clear_apertures()
+        self.clear_doors()
+
+    def clear_apertures(self):
+        """Remove all apertures from the face."""
+        for aperture in self._apertures:
+            aperture._parent = None
+        self._apertures = []
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def clear_doors(self):
+        """Remove all doors from the face."""
+        for door in self._apertures:
+            door._parent = None
+        self._doors = []
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def add_aperture(self, aperture):
+        """Add an Aperture to this face.
+
+        This method does not check the co-planarity between this Face and the
+        Aperture or whether the Aperture has all vertices within the boundary of
+        this Face. To check this, the Face3D.is_sub_face() method can be used
+        with the Aperture and Face geometry before using this method or the
+        are_sub_faces_valid() method can be used afterwards.
+
+        Args:
+            aperture: An Aperture to add to this face.
+        """
+        assert isinstance(aperture, Aperture), \
+            'Expected Aperture. Got {}.'.format(type(aperture))
+        self._acceptable_sub_face_check(Aperture)
+        aperture._parent = self
+        if self.normal.angle(aperture.normal) > math.pi / 2:  # reversed normal
+            aperture._geometry = aperture._geometry.flip()
+        self._apertures.append(aperture)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def add_door(self, door):
+        """Add a Door to this face.
+
+        This method does not check the co-planarity between this Face and the
+        Door or whether the Door has all vertices within the boundary of
+        this Face. To check this, the Face3D.is_sub_face() method can be used
+        with the Door and Face geometry before using this method or the
+        are_sub_faces_valid() method can be used afterwards.
+
+        Args:
+            door: A Door to add to this face.
+        """
+        assert isinstance(door, Door), \
+            'Expected Door. Got {}.'.format(type(door))
+        self._acceptable_sub_face_check(Door)
+        door._parent = self
+        if self.normal.angle(door.normal) > math.pi / 2:  # reversed normal
+            door._geometry = door._geometry.flip()
+        self._doors.append(door)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def add_apertures(self, apertures):
+        """Add a list of Apertures to this face."""
+        for aperture in apertures:
+            self.add_aperture(aperture)
+
+    def add_doors(self, doors):
+        """Add a list of Doors to this face."""
+        for door in doors:
+            self.add_door(door)
+
+    def set_adjacency(self, other_face, tolerance=0):
+        """Set this face adjacent to another and set the other face adjacent to this one.
+
+        Note that this method does not verify whether the other_face geometry is
+        co-planar or compatible with this one so it is recommended that either the
+        Face3D.is_centered_adjacent() or the Face3D.is_geometrically_equivalent()
+        method be used with this face geometry and the other_face geometry
+        before using this method in order to verify these criteria.
+
+        However, this method will use the proximity of apertures and doors within
+        the input tolerance to determine which of the sub faces in the other_face
+        are adjacent to the ones in this face. An exception will be thrown if not
+        all sub-faces can be matched.
+
+        Args:
+            other_face: Another Face object to be set adjacent to this one.
+            tolerance: The minimum distance between the center of two aperture
+                geometries at which they are condsidered adjacent. Default: 0.
+        """
+        # check the inputs and the ability of the faces to be adjacent
+        assert isinstance(other_face, Face), \
+            'Expected honeybee Face. Got {}.'.format(type(other_face))
+        assert len(self._apertures) == len(other_face._apertures), \
+            'Number of apertures does not match between {} and {}.'.format(
+                self.name, other_face.name)
+        assert len(self._doors) == len(other_face._doors), \
+            'Number of doors does not match between {} and {}.'.format(
+                self.name, other_face.name)
+        # set the boundary conditions of the faces
+        self._boundary_condition = Surface(other_face)
+        other_face._boundary_condition = Surface(self)
+        # set the apertures to be adjacent to one another
+        if len(self._apertures) > 0:
+            found_adjacencies = 0
+            for aper_1 in self._apertures:
+                for aper_2 in other_face._apertures:
+                    if aper_1.center.distance_to_point(aper_2.center) <= tolerance:
+                        aper_1.set_adjacency(aper_2)
+                        found_adjacencies += 1
+                        break
+            assert len(self._apertures) == found_adjacencies, \
+                'Not all apertures of {} were found to be adjacent to apertures in {}.' \
+                '\nTry increasing the tolerance.'.format(self.name, other_face.name)
+        # set the doors to be adjacent to one another
+        if len(self._doors) > 0:
+            found_adjacencies = 0
+            for door_1 in self._doors:
+                for door_2 in other_face._doors:
+                    if door_1.center.distance_to_point(door_2.center) <= tolerance:
+                        door_1.set_adjacency(door_2)
+                        found_adjacencies += 1
+                        break
+            assert len(self._doors) == found_adjacencies, \
+                'Not all doors of {} were found to be adjacent to doors in {}.' \
+                '\nTry increasing the tolerance.'.format(self.name, other_face.name)
+
+    def apertures_by_ratio(self, ratio, tolerance=0):
+        """Add apertures to this Face given a ratio of aperture area to facea area.
+
+        This method attempts to generate as few apertures as necessary to meet the ratio.
+        Note that this method will remove all existing apertures and doors on this face.
+
+        Args:
+            ratio: A number between 0 and 1  (but not perfectly equal to 1)
+                for the desired ratio between aperture area and face area.
+            tolerance: The maximum difference between point values for them to be
+                considered a part of a rectangle. This is used in the event that
+                this face is concave and an attempt to subdivide the face into a
+                rectangle is made. It does not affect the ability to produce apertures.
+
+        Usage:
+            room = Room.from_box(3.0, 6.0, 3.2, 180)
+            room[1].apertures_by_ratio(0.4)
+        """
+        assert 0 <= ratio < 1, 'Ratio must be between 0 and 1. Got {}'.format(ratio)
+        self._acceptable_sub_face_check(Aperture)
+        self.clear_sub_faces()
+        if ratio == 0:
+            return
+        else:
+            ap_faces = self._geometry.sub_faces_by_ratio_rectangle(ratio, tolerance)
+        for i, ap_face in enumerate(ap_faces):
+            aperture = Aperture('{}_Glz{}'.format(self.name_original, i), ap_face)
+            aperture._parent = self
+            self._apertures.append(aperture)
+
+    def apertures_by_ratio_rectangle(self, ratio, aperture_height, sill_height,
+                                     horizontal_separation, vertical_separation=0,
+                                     tolerance=0):
+        """Add apertures to this face given a ratio of aperture area to face area.
+
+        This function is virtually equivalent to the apertures_by_ratio method but
+        any rectangular portions of this face will produce customizable rectangular
+        apertures using the other inputs (aperture_height, sill_height,
+        horizontal_separation, vertical_separation).
+
+        Args:
+            ratio: A number between 0 and 0.95 for the ratio between the area of
+                the apertures and the area of this face.
+            aperture_height: A number for the target height of the output apertures.
+                Note that, if the ratio is too large for the height, the ratio will
+                take precedence and the actual aperture_height will be larger
+                than this value.
+            sill_height: A number for the target height above the bottom edge of
+                the rectangle to start the apertures. Note that, if the
+                ratio is too large for the height, the ratio will take precedence
+                and the sill_height will be smaller than this value.
+            horizontal_separation: A number for the target separation between
+                individual aperture centerlines.  If this number is larger than
+                the parent rectangle base, only one aperture will be produced.
+            vertical_separation: An optional number to create a single vertical
+                separation between top and bottom apertures. The default is
+                0 for no separation.
+            tolerance: The maximum difference between point values for them to be
+                considered a part of a rectangle.
+
+        Usage:
+            room = Room.from_box(3.0, 6.0, 3.2, 180)
+            room[1].apertures_by_ratio_rectangle(0.4, 2, 0.9, 3)
+        """
+        assert 0 <= ratio <= 0.95, \
+            'Ratio must be between 0 and 0.95. Got {}'.format(ratio)
+        self._acceptable_sub_face_check(Aperture)
+        self.clear_sub_faces()
+        if ratio == 0:
+            return
+        else:
+            ap_faces = self._geometry.sub_faces_by_ratio_sub_rectangle(
+                ratio, aperture_height, sill_height, horizontal_separation,
+                vertical_separation, tolerance)
+        for i, ap_face in enumerate(ap_faces):
+            aperture = Aperture('{}_Glz{}'.format(self.name_original, i), ap_face)
+            aperture._parent = self
+            self._apertures.append(aperture)
+
+    def aperture_by_width_height(self, width, height, sill_height=1,
+                                 aperture_name=None):
+        """Add a single rectangular aperture to the center of this face.
+
+        While the resulting aperture will always be in the plane of this Face,
+        this method will not check to ensure that the aperture has all of its
+        vertices completely within the boundary of this Face. The
+        are_sub_faces_valid() method can be used afterwards to check this.
+
+        Args:
+            width: Aperture width. Aperture will be centered along.
+            height: Aperture height.
+            sill_height: Sill height (default: 1).
+            aperture_name: Optional name for the aperture. If None, the default name
+                will follow the convention "[face_name]_Glz[count]" where [count]
+                is one more than the current numer of apertures in the face.
+
+        Usage:
+            room = Room.from_box(3.0, 6.0, 3.2, 180)
+            room[1].aperture_by_width_height(2, 2, .7)  # aperture in front
+            room[2].aperture_by_width_height(4, 1.5, .5)  # aperture on right
+            room[2].aperture_by_width_height(4, 0.5, 2.2)  # aperture on right
+        """
+        # Perform checks
+        self._acceptable_sub_face_check(Aperture)
+        # Generate the aperture geometry
+        face_plane = Plane(self._geometry.plane.n, self._geometry.min)
+        if face_plane.y.z < 0:
+            face_plane = face_plane.rotate(face_plane.n, math.pi, face_plane.o)
+        center2d = face_plane.xyz_to_xy(self._geometry.center)
+        x_dist = width / 2
+        lower_left = Point2D(center2d.x - x_dist, sill_height)
+        lower_right = Point2D(center2d.x + x_dist, sill_height)
+        upper_right = Point2D(center2d.x + x_dist, sill_height + height)
+        upper_left = Point2D(center2d.x - x_dist, sill_height + height)
+        ap_verts2d = (lower_left, lower_right, upper_right, upper_left)
+        ap_verts3d = tuple(face_plane.xy_to_xyz(pt) for pt in ap_verts2d)
+        ap_face = Face3D(ap_verts3d, self._geometry.plane)
+        if self.normal.angle(ap_face.normal) > math.pi / 2:  # reversed normal
+            ap_face = ap_face.flip()
+
+        # Create the aperture and add it to this Face
+        name = aperture_name or '{}_Glz{}'.format(
+            self.name_original, len(self.apertures))
+        aperture = Aperture(name, ap_face)
+        aperture._parent = self
+        self._apertures.append(aperture)
+
+    def overhang(self, depth, angle=0, indoor=False, tolerance=0):
+        """Get a overhang over this entire Face.
+
+        Args:
+            depth: A number for the overhang depth.
+            angle: A number for the for an angle to rotate the overhang in degrees.
+                Default is 0 for no rotation.
+            indoor: Boolean for whether the overhang should be generated facing the
+                opposite direction of the aperture normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to return None if the overhang has a length less
+                than the tolerance. Default is 0, which will always yeild an overhang.
+
+        Returns:
+            overhang: A Shade object for the Face overhang. You may want to run
+                the check_non_zero() method on the resulting Shade to verify
+                the geometry is subtantial when the Aperture does not have a flat top.
+        """
+        overhang = self.louvers_by_number(
+            1, depth, angle=angle, indoor=indoor, tolerance=tolerance)
+        return overhang[0] if len(overhang) != 0 else None
+
+    def louvers_by_number(self, louver_count, depth, offset=0, angle=0,
+                          contour_vector=Vector3D(0, 0, 1),
+                          flip_start_side=False, indoor=False, tolerance=0):
+        """Get a list of louvered Shade objects over this entire Face.
+
+        Args:
+            louver_count: A positive integer for the number of louvers to generate.
+            depth: A number for the depth to extrude the louvers.
+            offset: A number for the distance to louvers from this Face.
+                Default is 0 for no offset.
+            angle: A number for the for an angle to rotate the louvers in degrees.
+                Default is 0 for no rotation.
+            contour_vector: A Vector3D for the direction along which contours
+                are generated. Default is Z-Axis, which generates horizontal louvers.
+            flip_start_side: Boolean to note whether the side the louvers start from
+                should be flipped. Default is False to have louvers on top or right.
+                Setting to True will start contours on the bottom or left.
+            indoor: Boolean for whether louvers should be generated facing the
+                opposite direction of the Face normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to remove any louvers with a length less
+                than the tolerance. Default is 0, which will include all louvers
+                no matter how small.
+
+        Returns:
+            louvers: A list of Shade objects that cover the Face.
+        """
+        assert louver_count > 0, 'louver_count must be greater than 0.'
+        angle = math.radians(angle)
+        louvers = []
+        face_geo = self.geometry if indoor is False else self.geometry.flip()
+        shade_faces = face_geo.countour_fins_by_number(
+            louver_count, depth, offset, angle,
+            contour_vector, flip_start_side, tolerance)
+        for i, shade_geo in enumerate(shade_faces):
+            louvers.append(Shade('{}_Shd{}'.format(self.name_original, i), shade_geo))
+        return louvers
+
+    def louvers_by_distance_between(self, distance, depth, offset=0, angle=0,
+                                    contour_vector=Vector3D(0, 0, 1),
+                                    flip_start_side=False, indoor=False, tolerance=0):
+        """Get a list of louvered Shade objects over this entire Face.
+
+        Args:
+            distance: A number for the approximate distance between each louver.
+            depth: A number for the depth to extrude the louvers.
+            offset: A number for the distance to louvers from this Face.
+                Default is 0 for no offset.
+            angle: A number for the for an angle to rotate the louvers in degrees.
+                Default is 0 for no rotation.
+            contour_vector: A Vector3D for the direction along which contours
+                are generated. Default is Z-Axis, which generates horizontal louvers.
+            flip_side: Boolean to note whether the side the louvers start from
+                should be flipped. Default is False to have contours on top or right.
+                Setting to True will start contours on the bottom or left.
+            indoor: Boolean for whether louvers should be generated facing the
+                opposite direction of the Face normal (typically meaning
+                indoor geometry). Default: False.
+            tolerance: An optional value to remove any louvers with a length less
+                than the tolerance. Default is 0, which will include all louvers
+                no matter how small.
+
+        Returns:
+            louvers: A list of Shade objects that cover the Face.
+        """
+        angle = math.radians(angle)
+        louvers = []
+        face_geo = self.geometry if indoor is False else self.geometry.flip()
+        shade_faces = face_geo.countour_fins_by_distance_between(
+            distance, depth, offset, angle, contour_vector, flip_start_side, tolerance)
+        for i, shade_geo in enumerate(shade_faces):
+            louvers.append(Shade('{}_Shd{}'.format(self.name_original, i), shade_geo))
+        return louvers
+
+    def move(self, moving_vec):
+        """Move this Face along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the face.
+        """
+        self._geometry = self.geometry.move(moving_vec)
+        for ap in self._apertures:
+            ap.move(moving_vec)
+        for dr in self._doors:
+            dr.move(moving_vec)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def rotate(self, axis, angle, origin):
+        """Rotate this Face by a certain angle around an axis and origin.
+
+        Args:
+            axis: A ladybug_geometry Vector3D axis representing the axis of rotation.
+            angle: An angle for rotation in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        ang = math.radians(angle)
+        self._geometry = self.geometry.rotate(axis, ang, origin)
+        for ap in self._apertures:
+            ap.rotate(axis, ang, origin)
+        for dr in self._doors:
+            dr.rotate(axis, ang, origin)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this Face counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        ang = math.radians(angle)
+        self._geometry = self.geometry.rotate_xy(ang, origin)
+        for ap in self._apertures:
+            ap.rotate_xy(ang, origin)
+        for dr in self._doors:
+            dr.rotate_xy(ang, origin)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def reflect(self, plane):
+        """Reflect this Face across a plane with the input normal vector and origin.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        assert isinstance(plane, Plane), \
+            'Expected ladybug_geometry Plane. Got {}.'.format(type(plane))
+        self._geometry = self.geometry.reflect(plane.n, plane.o)
+        for ap in self._apertures:
+            ap.reflect(plane)
+        for dr in self._doors:
+            dr.reflect(plane)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def scale(self, factor, origin=None):
+        """Scale this Face by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self._geometry = self.geometry.scale(factor, origin)
+        for ap in self._apertures:
+            ap.scale(factor, origin)
+        for dr in self._doors:
+            dr.scale(factor, origin)
+        self._punched_geometry = None  # reset so that it can be re-computed
+
+    def check_sub_faces_valid(self, tolerance, angle_tolerance, raise_exception=True):
+        """Check that sub-faces are co-planar with this Face within the Face boundary.
+
+        Note this does not check the planarity of the sub-faces themselves, whether
+        they self-intersect, or whether they have a non-zero area.
+
+        Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent.
+            angle_tolerance: The max angle in degrees that the plane normals can
+                differ from one another in order for them to be considered coplanar.
+            raise_exception: Boolean to note whether a ValueError should be raised
+                if an sub-face is not valid.
+        """
+        ap = self.check_apertures_valid(tolerance, angle_tolerance, raise_exception)
+        dr = self.check_doors_valid(tolerance, angle_tolerance, raise_exception)
+        return True if ap and dr else False
+
+    def check_apertures_valid(self, tolerance, angle_tolerance, raise_exception=True):
+        """Check that apertures are co-planar with this Face within the Face boundary.
+
+        Note this does not check the planarity of the apertures themselves, whether
+        they self-intersect, or whether they have a non-zero area.
+
+        Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent.
+            angle_tolerance: The max angle in degrees that the plane normals can
+                differ from one another in order for them to be considered coplanar.
+            raise_exception: Boolean to note whether a ValueError should be raised
+                if an aperture is not valid.
+        """
+        for ap in self._apertures:
+            if not self.geometry.is_sub_face(ap.geometry, tolerance, angle_tolerance):
+                if raise_exception:
+                    raise ValueError(
+                        'Aperture "{}" is not coplanar or fully bounded by its parent '
+                        'Face "{}".'.format(ap.name_original, self.name_original))
+                return False
+        return True
+
+    def check_doors_valid(self, tolerance, angle_tolerance, raise_exception=True):
+        """Check that doors are co-planar with this Face within the Face boundary.
+
+        Note this does not check the planarity of the doors themselves, whether
+        they self-intersect, or whether they have a non-zero area.
+
+        Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent.
+            angle_tolerance: The max angle in degrees that the plane normals can
+                differ from one another in order for them to be considered coplanar.
+            raise_exception: Boolean to note whether a ValueError should be raised
+                if an door is not valid.
+        """
+        for dr in self._doors:
+            if not self.geometry.is_sub_face(dr.geometry, tolerance, angle_tolerance):
+                if raise_exception:
+                    raise ValueError(
+                        'Door "{}" is not coplanar or fully bounded by its parent '
+                        'Face "{}".'.format(dr.name_original, self.name_original))
+                return False
+        return True
+
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check whether all of the Face's vertices lie within the same plane.
+
+        Args:
+            tolerance: The minimum distance between a given vertex and a the
+                object's's plane at which the vertex is said to lie in the plane.
+            raise_exception: Boolean to note whether an ValueError should be
+                raised if a vertex does not lie within the object's plane.
+        """
+        try:
+            return self.geometry.validate_planarity(tolerance, raise_exception)
+        except ValueError as e:
+            raise ValueError('Face "{}" is not planar.\n{}'.format(
+                self.name_original, e))
+
+    def check_self_intersecting(self, raise_exception=True):
+        """Check whether the edges of the Face intersect one another (like a bowtwie).
+
+        Args:
+            raise_exception: If True, a ValueError will be raised if the object
+                intersects with itself. Default: True.
+        """
+        if self.geometry.is_self_intersecting:
+            if raise_exception:
+                raise ValueError('Face "{}" has self-intersecting edges.'.format(
+                    self.name_original))
+            return False
+        return True
+
+    def check_non_zero(self, tolerance=0.0001, raise_exception=True):
+        """Check whether the area of the Face is above a certain "zero" tolerance.
+
+        Args:
+            tolerance: The minimum acceptable area of the object. Default is 0.0001,
+                which is equal to 1 cm2 when model units are meters. This is just
+                above the smalest size that OpenStudio will accept.
+            raise_exception: If True, a ValueError will be raised if the object
+                area is below the tolerance. Default: True.
+        """
+        if self.area < tolerance:
+            if raise_exception:
+                raise ValueError(
+                    'Face "{}" geometry is too small. Area must be at least {}. '
+                    'Got {}.'.format(self.name_original, tolerance, self.area))
+            return False
+        return True
 
     @property
     def properties(self):
-        """Face properties.
-
-        Radiance, energy and other face properties.
-        """
+        """Face properties, including Radiance, Energy and other properties."""
         return self._properties
 
     @property
     def to(self):
         """Face writer object.
 
-        Use this method to access Writer class to write the face in different formats.
+        Use this method to access Writer class to write the face in other formats.
 
-        face.to.idf(face) -> idf string.
-        face.to.radiance(face) -> Radiance string.
+        Usage:
+            face.to.idf(face) -> idf string.
+            face.to.radiance(face) -> Radiance string.
         """
-        return self._writer
+        return writer
 
-    def to_dict(self, included_prop=None):
+    def to_dict(self, abridged=False, included_prop=None):
         """Return Face as a dictionary.
 
-        args:
-            included_prop: Use properties filter to filter keys that must be included in
-            output dictionary. For example ['energy'] will include 'energy' key if
-            available in properties to_dict. By default all the keys will be included.
-            To exclude all the keys from plugins use an empty list.
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            included_prop: List of properties to filter keys that must be included in
+                output dictionary. For example ['energy'] will include 'energy' key if
+                available in properties to_dict. By default all the keys will be
+                included. To exclude all the keys from plugins use an empty list.
         """
         base = {
             'type': self.__class__.__name__,
             'name': self.name,
             'name_original': self.name_original,
-            'vertices': [{'x': ver.x, 'y': ver.y, 'z': ver.z} for ver in self.vertices],
-            'properties': self.properties.to_dict(included_prop)
+            'geometry': self._geometry.to_dict(),
+            'face_type': self.type.to_dict(),
+            'properties': self.properties.to_dict(abridged, included_prop)
         }
-
+        if 'energy' in base['properties']:
+            base['boundary_condition'] = self.boundary_condition.to_dict(full=True)
+        else:
+            base['boundary_condition'] = self.boundary_condition.to_dict(full=False)
         if self.parent:
-            base['parent'] = {'name': self.parent.name}
-
-        if self.apertures:
-            base['apertures'] = [ap.to_dict(included_prop) for ap in self.apertures]
-
+            base['parent'] = self.parent.name
+        else:
+            base['parent'] = None
+        if self.apertures != []:
+            base['apertures'] = \
+                [ap.to_dict(abridged, included_prop) for ap in self.apertures]
+        if self.doors != []:
+            base['doors'] = \
+                [dr.to_dict(abridged, included_prop) for dr in self.doors]
         return base
 
+    def _acceptable_sub_face_check(self, sub_face_type=Aperture):
+        """Check whether the Face can accept sub-faces and raise an excption if not."""
+        assert isinstance(self.boundary_condition, Outdoors), \
+            '{} can only be added to Faces with a Outdoor boundary condition.'.format(
+                sub_face_type.__name__)
+        assert not isinstance(self.type, AirWall), \
+            '{} cannot be added to AirWalls.'.format(sub_face_type.__name__)
 
-    def add_aperture(self, aperture):
-        """Add an aperture to face."""
-        aperture._parent = self
-        self._apertures.append(weakref.proxy(aperture))
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
 
     def ToString(self):
         return self.__repr__()
 
+    def __copy__(self):
+        new_f = Face(self.name_original, self.geometry, self.type,
+                     self.boundary_condition)
+        new_f._apertures = [ap.duplicate() for ap in self._apertures]
+        new_f._doors = [dr.duplicate() for dr in self._doors]
+        for ap in new_f._apertures:
+            ap._parent = new_f
+        for dr in new_f._doors:
+            dr._parent = new_f
+        new_f._punched_geometry = self._punched_geometry
+        new_f._properties.duplicate_extension_attr(self._properties)
+        return new_f
+
     def __repr__(self):
-        return 'Face:%s' % self.name_original
+        return 'Face: %s' % self.name_original

--- a/honeybee/facetype.py
+++ b/honeybee/facetype.py
@@ -1,34 +1,59 @@
-"""Energy Types."""
+"""Face Types."""
 from ladybug_geometry.geometry3d.pointvector import Vector3D
 import math
 
 
 class _FaceType(object):
+    __slots__ = ()
+
     @property
     def name(self):
         return self.__class__.__name__
+
+    def to_dict(self):
+        """ApertureType as a dictionary."""
+        ap_type_dict = {
+            'type': self.name}
+        return ap_type_dict
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __repr__(self):
         return self.name
 
 
 class Wall(_FaceType):
+    """Type for walls."""
+    __slots__ = ()
     pass
 
 
 class RoofCeiling(_FaceType):
+    """Type for roofs and ceilings."""
+    __slots__ = ()
     pass
 
 
 class Floor(_FaceType):
+    """Type for floors."""
+    __slots__ = ()
     pass
 
 
 class AirWall(_FaceType):
-    pass
+    """Type for virtual partitions between Rooms.
 
-
-class Shading(_FaceType):
+    Note that the use of the word 'Wall' in AirWall does not limit the application
+    of this type to vertical faces. It can be applied to any face between two Rooms.
+    """
+    __slots__ = ()
     pass
 
 
@@ -40,7 +65,6 @@ class _Types(object):
         self._roof_ceiling = RoofCeiling()
         self._floor = Floor()
         self._air_wall = AirWall()
-        self._shading = Shading()
 
     @property
     def wall(self):
@@ -55,12 +79,8 @@ class _Types(object):
         return self._floor
 
     @property
-    def airwall(self):
+    def air_wall(self):
         return self._air_wall
-
-    @property
-    def shading(self):
-        return self._shading
 
     def __contains__(self, value):
         return isinstance(value, _FaceType)
@@ -77,18 +97,15 @@ def get_type_from_normal(normal_vector, roof_angle=30, floor_angle=150):
     Angles larger than floor angle will be set to floor.
 
     args:
-        normal_vector: Normal vector as a ladybug Vector3D.
-        roof_angle: Cutting angle for roof from Z axis (default: 30).
-        floor_angle: Cutting angle for floor from Z axis (default: 150).
-    
-    returns:
-        face type.
-    """
+        normal_vector: Normal vector as a ladybug_geometry Vector3D.
+        roof_angle: Cutting angle for roof from Z axis in degrees (default: 30).
+        floor_angle: Cutting angle for floor from Z axis in degrees (default: 150).
 
-    roof_angle = math.radians(roof_angle)
-    floor_angle = math.radians(floor_angle)
+    Returns:
+        Face type instance.
+    """
     z_axis = Vector3D(0, 0, 1)
-    angle = z_axis.angle(normal_vector)
+    angle = math.degrees(z_axis.angle(normal_vector))
     if angle < roof_angle:
         return face_types.roof_ceiling
     elif roof_angle <= angle < floor_angle:

--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -1,0 +1,586 @@
+# coding: utf-8
+"""Honeybee Model."""
+from .properties import ModelProperties
+from .room import Room
+from .face import Face
+from .shade import Shade
+from .aperture import Aperture
+from .door import Door
+from .boundarycondition import Outdoors, Surface
+from .facetype import AirWall
+from .typing import valid_string, float_in_range
+import honeybee.writer as writer
+
+from ladybug_geometry.geometry2d.pointvector import Vector2D
+from ladybug_geometry.geometry3d.face import Face3D
+
+import math
+
+
+class Model(object):
+    """A collection of Rooms, Faces, Shades, Apertures, and Doors representing a model.
+
+    Properties:
+        name
+        name_original
+        north_angle
+        north_vector
+        rooms
+        faces
+        shades
+        apertures
+        doors
+        has_ngon_apertures
+        had_ngon_doors
+    """
+    __slots__ = ('_name', '_name_original', '_rooms', '_faces', '_shades',
+                 '_apertures', '_doors', '_room_names', '_face_names', '_shade_names',
+                 '_aperture_names', '_door_names', '_properties')
+
+    def __init__(self, name, objects, north_angle=0):
+        """A collection of Rooms, Faces, Apertures, and Doors for an entire model.
+
+        Args:
+            name: Model name. Must be < 100 characters.
+            objects: A list of honeybee Rooms, Faces, Apertures, and Doors.
+            north_angle: An number between 0 and 360 to set the clockwise north
+                direction in degrees. Default is 0.
+        """
+        self._name = valid_string(name, 'honeybee model name')
+        self._name_original = name
+        self.north_angle = north_angle
+
+        self._rooms = []
+        self._faces = []
+        self._shades = []
+        self._apertures = []
+        self._doors = []
+        self._room_names = []
+        self._face_names = []
+        self._shade_names = []
+        self._aperture_names = []
+        self._door_names = []
+        for obj in objects:
+            if isinstance(obj, Room):
+                self.add_room(obj)
+            elif isinstance(obj, Face):
+                self.add_face(obj)
+            elif isinstance(obj, Shade):
+                self.add_shade(obj)
+            elif isinstance(obj, Aperture):
+                self.add_aperture(obj)
+            elif isinstance(obj, Door):
+                self.add_door(obj)
+            else:
+                raise TypeError('Expected Room, Face, Shade, Aperture or Door '
+                                'for Model. Got {}'.format(type(obj)))
+
+        self._properties = ModelProperties(self)
+
+    @property
+    def name(self):
+        """The model name (including only legal characters)."""
+        return self._name
+
+    @property
+    def name_original(self):
+        """Original input name by user.
+
+        If there are no illegal characters in name then name and name_original will
+        be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
+        Invalid characters are automatically removed from the original name for
+        compatability with simulation engines.
+        """
+        return self._name_original
+
+    @property
+    def north_angle(self):
+        """Get or set a number between 0 and 360 for the north direction in degrees."""
+        return self._north_angle
+
+    @north_angle.setter
+    def north_angle(self, value):
+        self._north_angle = float_in_range(value, 0.0, 360.0, 'model north angle')
+        self._north_vector = Vector2D(0, 1).rotate(math.radians(-self._north_angle))
+
+    @property
+    def north_vector(self):
+        """Get or set a ladybug_geometry Vector2D for the north direction."""
+        return self._north_vector
+
+    @north_vector.setter
+    def north_vector(self, value):
+        assert isinstance(value, Vector2D), \
+            'Expected Vector2D for north_vector. Got {}.'.format(type(value))
+        self._north_vector = value
+        self._north_angle = \
+            math.degrees(Vector2D(0, 1).angle_clockwise(self._north_vector))
+
+    @property
+    def rooms(self):
+        """A list of all Room objects in the model."""
+        return self._rooms
+
+    @property
+    def faces(self):
+        """A list of all Face objects in the model."""
+        return self._faces
+
+    @property
+    def shades(self):
+        """A list of all Shades objects in the model."""
+        return self._shades
+
+    @property
+    def apertures(self):
+        """A list of all Aperture objects in the model."""
+        return self._apertures
+
+    @property
+    def doors(self):
+        """A list of all Door objects in the model."""
+        return self._doors
+
+    @property
+    def has_ngon_apertures(self):
+        """Boolean noting whether the model has apertures with more than 4 sides.
+
+        This is helpful for energy simulation since EnergyPlus cannot accept
+        sub-faces with more than 4 sides. This property should be checked before
+        running the triangulate_ngon_apertures() method since many models do not
+        have such apertures.
+        """
+        for ap in self.apertures:
+            if len(ap.geometry) > 4:
+                return True
+        return False
+
+    @property
+    def has_ngon_doors(self):
+        """Boolean noting whether the model has doors with more than 4 sides.
+
+        This is helpful for energy simulation since EnergyPlus cannot accept
+        sub-faces with more than 4 sides. This property should be checked before
+        running the triangulate_ngon_doors() method since many models do not have
+        such doors.
+        """
+        for dr in self.doors:
+            if len(dr.geometry) > 4:
+                return True
+        return False
+
+    def get_room(self, name):
+        """Get a room object in the model given the room name."""
+        return self._rooms[self._room_names.index(name)]
+
+    def get_face(self, name):
+        """Get a face object in the model given the face name."""
+        return self._faces[self._face_names.index(name)]
+
+    def get_shade(self, name):
+        """Get a shade object in the model given the shade name."""
+        return self._shades[self._shade_names.index(name)]
+
+    def get_aperture(self, name):
+        """Get an aperture object in the model given the aperture name."""
+        return self._apertures[self._aperture_names.index(name)]
+
+    def get_door(self, name):
+        """Get an door object in the model given the door name."""
+        return self._doors[self._door_names.index(name)]
+
+    def add_model(self, other_model):
+        """Add another Model object to this model."""
+        assert isinstance(other_model, Model), \
+            'Expected Model. Got {}.'.format(type(other_model))
+        for room in other_model.rooms:
+            self.add_room(room)
+        for face in other_model.faces:
+            if not face.has_parent:
+                self.add_face(face)
+        for shade in other_model.shades:
+            if not shade.has_parent:
+                self.add_shade(shade)
+        for aperture in other_model.apertures:
+            if not aperture.has_parent:
+                self.add_aperture(aperture)
+        for door in other_model.doors:
+            if not door.has_parent:
+                self.add_door(door)
+
+    def add_room(self, obj):
+        """Add a Room object to the model."""
+        assert isinstance(obj, Room), 'Expected Room. Got {}.'.format(type(obj))
+        self._rooms.append(obj)
+        self._room_names.append(obj.name)
+        for face in obj.faces:
+            self.add_face(face)
+        for shade in obj.indoor_shades:
+            self.add_shade(shade)
+        for shade in obj.outdoor_shades:
+            self.add_shade(shade)
+
+    def add_face(self, obj):
+        """Add a Face object to the model."""
+        assert isinstance(obj, Face), 'Expected Face. Got {}.'.format(type(obj))
+        self._faces.append(obj)
+        self._face_names.append(obj.name)
+        for ap in obj.apertures:
+            self.add_aperture(ap)
+        for dr in obj.doors:
+            self.add_door(dr)
+
+    def add_shade(self, obj):
+        """Add an Shade object to the model."""
+        assert isinstance(obj, Shade), 'Expected Shade. Got {}.'.format(type(obj))
+        self._shades.append(obj)
+        self._shade_names.append(obj.name)
+
+    def add_aperture(self, obj):
+        """Add an Aperture object to the model."""
+        assert isinstance(obj, Aperture), 'Expected Aperture. Got {}.'.format(type(obj))
+        self._apertures.append(obj)
+        self._aperture_names.append(obj.name)
+
+    def add_door(self, obj):
+        """Add an Door object to the model."""
+        assert isinstance(obj, Door), 'Expected Door. Got {}.'.format(type(obj))
+        self._doors.append(obj)
+        self._door_names.append(obj.name)
+
+    def check_duplicate_room_names(self, raise_exception=True):
+        """Check that there are no duplicate room names in the model."""
+        room_count = len(self._room_names)
+        unique_room_count = len(set(self._room_names))
+        if room_count != unique_room_count:
+            if raise_exception:
+                raise ValueError('Model "{}" has {} duplicated room names.'.format(
+                                 self.name_original, room_count - unique_room_count))
+            return False
+        return True
+
+    def check_duplicate_face_names(self, raise_exception=True):
+        """Check that there are no duplicate face names in the model."""
+        face_count = len(self._face_names)
+        unique_face_count = len(set(self._face_names))
+        if face_count != unique_face_count:
+            if raise_exception:
+                raise ValueError('Model "{}" has {} duplicated face names.'.format(
+                                 self.name_original, face_count - unique_face_count))
+            return False
+        return True
+
+    def check_duplicate_shade_names(self, raise_exception=True):
+        """Check that there are no duplicate shade names in the model."""
+        shade_count = len(self._shade_names)
+        unique_shade_count = len(set(self._shade_names))
+        if shade_count != unique_shade_count:
+            if raise_exception:
+                raise ValueError('Model "{}" has {} duplicated shade names.'.format(
+                                 self.name_original, shade_count - unique_shade_count))
+            return False
+        return True
+
+    def check_duplicate_sub_face_names(self, raise_exception=True):
+        """Check that there are no duplicate sub-face names in the model.
+
+        Note that both apertures and doors are checked for duplicates since the two
+        are counted together by EnergyPlus.
+        """
+        sub_face_names = self._aperture_names + self._door_names
+        sf_count = len(sub_face_names)
+        unique_sf_count = len(set(sub_face_names))
+        if sf_count != unique_sf_count:
+            if raise_exception:
+                raise ValueError('Model "{}" has {} duplicated sub-face names.'.format(
+                                 self.name_original, sf_count - unique_sf_count))
+            return False
+        return True
+
+    def check_missing_adjacencies(self, raise_exception=True):
+        """Check that all faces have adjacent objects that exist in the model."""
+        for room in self.rooms:
+            for face in room._faces:
+                if isinstance(face.boundary_condition, Surface):
+                    bc_obj_name = face.boundary_condition.boundary_condition_object
+                    if bc_obj_name not in self._face_names:
+                        if raise_exception:
+                            raise ValueError(
+                                'Face "{}" has a boundary condition object that is '
+                                'missing from the model: {}.'.format(
+                                    face.name_original, bc_obj_name))
+                        return False
+        return True
+
+    def check_all_air_walls_adjacent(self, raise_exception=True):
+        """Check that all faces with AirWall type are adjacent to other faces.
+
+        This is a requirement for energy models.
+        """
+        for face in self.faces:
+            if isinstance(face.type, AirWall) and not \
+                    isinstance(face.boundary_condition, Surface):
+                if raise_exception:
+                    raise ValueError('Face "{}" is an AirWall but does not have Surface'
+                                     ' boundary condition.'.format(face.name_original))
+                return False
+        return True
+
+    def check_orphaned_faces(self, raise_exception=True):
+        """Check that there are no faces without a parent Room in the model.
+
+        This is a requirement for energy models.
+        """
+        for face in self.faces:
+            if not face.has_parent:
+                if raise_exception:
+                    raise ValueError('Face "{}" does not have a parent '
+                                     'Room.'.format(face.name_original))
+                return False
+        return True
+
+    def check_orphaned_apertures(self, raise_exception=True):
+        """Check that there are no orphaned apertures in the model."""
+        for ap in self.apertures:
+            if not ap.has_parent:
+                if raise_exception:
+                    raise ValueError('Aperture "{}" does not have a parent '
+                                     'Face.'.format(ap.name_original))
+                return False
+        return True
+
+    def check_orphaned_doors(self, raise_exception=True):
+        """Check that there are no orphaned doors in the model."""
+        for dr in self.doors:
+            if not dr.has_parent:
+                if raise_exception:
+                    raise ValueError('Door "{}" does not have a parent '
+                                     'Face.'.format(dr.name_original))
+                return False
+        return True
+
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check that all of the Model's geometry components are planar.
+
+        This includes all of the Model's Faces, Apertures, Doors and Shades.
+
+        Args:
+            tolerance: The minimum distance between a given vertex and a the
+                object's's plane at which the vertex is said to lie in the plane.
+            raise_exception: Boolean to note whether an ValueError should be
+                raised if a vertex does not lie within the object's plane.
+        """
+        for face in self.faces:
+            if not face.check_planar(tolerance, raise_exception):
+                return False
+        for shd in self.shades:
+            if not shd.check_planar(tolerance, raise_exception):
+                return False
+        for ap in self.apertures:
+            if not ap.check_planar(tolerance, raise_exception):
+                return False
+        for dr in self.doors:
+            if not dr.check_planar(tolerance, raise_exception):
+                return False
+        return True
+
+    def check_self_intersecting(self, raise_exception=True):
+        """Check that no edges of the Model's geometry components self-intersect.
+
+        This includes all of the Model's Faces, Apertures, Doors and Shades.
+
+        Args:
+            raise_exception: If True, a ValueError will be raised if an object
+                intersects with itself (like a bowtie). Default: True.
+        """
+        for face in self.faces:
+            if not face.check_self_intersecting(raise_exception):
+                return False
+        for shd in self.shades:
+            if not shd.check_self_intersecting(raise_exception):
+                return False
+        for ap in self.apertures:
+            if not ap.check_self_intersecting(raise_exception):
+                return False
+        for dr in self.doors:
+            if not dr.check_self_intersecting(raise_exception):
+                return False
+        return True
+
+    def check_non_zero(self, tolerance=0.0001, raise_exception=True):
+        """Check that the Model's geometry components are above a "zero" area tolerance.
+
+        This includes all of the Model's Faces, Apertures, Doors and Shades.
+
+        Args:
+            tolerance: The minimum acceptable area of the object. Default is 0.0001,
+                which is equal to 1 cm2 when model units are meters. This is just
+                above the smalest size that OpenStudio will accept.
+            raise_exception: If True, a ValueError will be raised if the object
+                area is below the tolerance. Default: True.
+        """
+        for face in self.faces:
+            if not face.check_non_zero(tolerance, raise_exception):
+                return False
+        for shd in self.shades:
+            if not shd.check_non_zero(tolerance, raise_exception):
+                return False
+        for ap in self.apertures:
+            if not ap.check_non_zero(tolerance, raise_exception):
+                return False
+        for dr in self.doors:
+            if not dr.check_non_zero(tolerance, raise_exception):
+                return False
+        return True
+
+    def triangulate_ngon_apertures(self):
+        """Triangulate all Apertures that have more than 4 sides in the model.
+
+        This is necessary for energy simulation since EnergyPlus cannot accept
+        sub-faces with more than 4 sides.
+        """
+        adjacent_check = [ap.name for ap in self.apertures]  # needed to check adjacency
+        for i, ap in enumerate(list(self.apertures)):  # copy to avoid edit while iterate
+            if len(ap.geometry) > 4 and adjacent_check[i]:
+                # generate the new triangulated apertures
+                ap_mesh3d = ap.triangulated_mesh3d
+                new_verts = [[ap_mesh3d[v] for v in face] for face in ap_mesh3d.faces]
+                new_ap_geo = [Face3D(verts, ap.geometry.plane) for verts in new_verts]
+                new_aps = self._replace_aperture(ap, new_ap_geo)
+                # coordinate new apertures with any adjacent apertures
+                if isinstance(ap.boundary_condition, Surface):
+                    adj_ap = self.get_aperture(
+                        ap.boundary_condition.boundary_condition_object)
+                    new_adj_ap_geo = [face.flip() for face in new_ap_geo]
+                    new_adj_aps = self._replace_aperture(adj_ap, new_adj_ap_geo)
+                    for new_ap, new_adj_ap in zip(new_aps, new_adj_aps):
+                        new_ap.set_adjacency(new_adj_ap)
+                    adj_i = adjacent_check.index(adj_ap.name)
+                    adjacent_check[adj_i] = False  # ensure we don't re-triangulate
+
+    def triangulate_ngon_doors(self):
+        """Triangulate all Doors that have more than 4 sides in the model.
+
+        This is necessary for energy simulation since EnergyPlus cannot accept
+        sub-faces with more than 4 sides.
+        """
+        adjacent_check = [dr.name for dr in self.doors]  # needed to check adjacency
+        for i, dr in enumerate(list(self.doors)):  # copy to avoid editing while iterate
+            if len(dr.geometry) > 4 and adjacent_check[i]:
+                # generate the new triangulated doors
+                dr_mesh3d = dr.triangulated_mesh3d
+                new_verts = [[dr_mesh3d[v] for v in face] for face in dr_mesh3d.faces]
+                new_dr_geo = [Face3D(verts, dr.geometry.plane) for verts in new_verts]
+                new_drs = self._replace_door(dr, new_dr_geo)
+                # coordinate new doors with any adjacent doors
+                if isinstance(dr.boundary_condition, Surface):
+                    adj_dr = self.get_door(
+                        dr.boundary_condition.boundary_condition_object)
+                    new_adj_dr_geo = [face.flip() for face in new_dr_geo]
+                    new_adj_drs = self._replace_door(adj_dr, new_adj_dr_geo)
+                    for new_dr, new_adj_dr in zip(new_drs, new_adj_drs):
+                        new_dr.set_adjacency(new_adj_dr)
+                    adj_i = adjacent_check.index(adj_dr.name)
+                    adjacent_check[adj_i] = False  # ensure we don't re-triangulate
+
+    def _replace_aperture(self, original_ap, new_ap_geo):
+        """Replace an aperture in the model with new ones built from new_ap_geo.
+
+        Note that this method does not re-link the new apertures to new adjacent
+        apertures in the model. This must be done with the returned apertures.
+
+        Args:
+            original_ap: The original Aperture object that is being replaced.
+            new_ap_geo: A list of ladybug_geometry Face3D objects that will be used
+                to replace the original Aperture object.
+
+        Returns:
+            new_aps: A list of the new Aperture objects that have been added to
+                the model.
+        """
+        # make the new Apertures and add them to the model
+        new_aps = []
+        for i, ap_face in enumerate(new_ap_geo):
+            new_ap = Aperture('{}_SubF{}'.format(original_ap.name_original, i),
+                              ap_face, Outdoors())
+            new_ap._properties = original_ap._properties  # transfer extension properties
+            if original_ap.has_parent:
+                new_ap._parent = original_ap.parent
+                original_ap.parent._apertures.append(new_ap)
+            self.add_aperture(new_ap)
+            new_aps.append(new_ap)
+        # delete the original Aperture from the model and from its parent Face
+        del_i = self._aperture_names.index(original_ap.name)
+        del self._apertures[del_i]
+        del self._aperture_names[del_i]
+        if original_ap.has_parent:
+            del_i = 0
+            for j, old_ap in enumerate(original_ap.parent._apertures):
+                if old_ap.name == original_ap.name:
+                    del_i = j
+                    break
+            del original_ap.parent._apertures[del_i]
+        return new_aps
+
+    def _replace_door(self, original_dr, new_dr_geo):
+        """Replace a door in the model with new ones built from new_dr_geo.
+
+        Note that this method does not re-link the new doors to new adjacent
+        doors in the model. This must be done with the returned doors.
+
+        Args:
+            original_dr: The original Door object that is being replaced.
+            new_dr_geo: A list of ladybug_geometry Face3D objects that will be used
+                to replace the original Door object.
+
+        Returns:
+            new_drs: A list of the new Door objects that have been added to
+                the model.
+        """
+        # make the new Doors and add them to the model
+        new_drs = []
+        for i, dr_face in enumerate(new_dr_geo):
+            new_dr = Door('{}_SubF{}'.format(original_dr.name_original, i),
+                          dr_face, Outdoors())
+            new_dr._properties = original_dr._properties  # transfer extension properties
+            if original_dr.has_parent:
+                new_dr._parent = original_dr.parent
+                original_dr.parent._doors.append(new_dr)
+            self.add_door(new_dr)
+            new_drs.append(new_dr)
+        # delete the original Door from the model and from its parent Face
+        del_i = self._door_names.index(original_dr.name)
+        del self._doors[del_i]
+        del self._door_names[del_i]
+        if original_dr.has_parent:
+            del_i = 0
+            for j, old_dr in enumerate(original_dr.parent._doors):
+                if old_dr.name == original_dr.name:
+                    del_i = j
+                    break
+            del original_dr.parent._doors[del_i]
+        return new_drs
+
+    @property
+    def properties(self):
+        """Model properties, including Radiance, Energy and other properties."""
+        return self._properties
+
+    @property
+    def to(self):
+        """Model writer object.
+
+        Use this method to access Writer class to write the model in other formats.
+
+        Usage:
+            model.to.idf(model) -> idf string.
+            model.to.radiance(model) -> Radiance string.
+        """
+        raise NotImplementedError('Model does not yet support writing to files.')
+        return writer
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return 'Model: %s' % self.name_original

--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -1,76 +1,62 @@
-"""Face Properties."""
-from .facetype import face_types
-from .boundarycondition import _BoundaryCondition, boundary_conditions
+"""Extension properties for Model, Room, Face, Shade, Aperture, Door.
+
+These objects hold all attributes assigned by extensions like honeybee-radiance
+and honeybee-energy.  Note that these Property objects are not intended to exist
+on their own but should have a host object.
+"""
 
 
-class Properties(object):
-    """Geometry Properties.
+class _Properties(object):
+    """Base class for all Properties classes."""
 
-    Base class for geometry properties. This class will be extended by plugins.
+    def __init__(self, host):
+        """Initialize properties.
 
-    prop = Properties(srf_type, boundary_condition)
-    prop.radiance -> RadianceProperties
-    prop.energy -> EnergyProperties
-    """
-    TYPES = face_types
-
-    def __init__(self, face_type, boundary_condition=None):
-        self.face_type = face_type
-        self.boundary_condition = boundary_condition or boundary_conditions.outdoors
-
-    @property
-    def face_type(self):
-        """Get and set Surface Type."""
-        return self._face_type
-
-    @face_type.setter
-    def face_type(self, value):
-        assert value in self.TYPES, '{} is not a valid type.'.format(value)
-        self._face_type = value
-
-    @property
-    def boundary_condition(self):
-        """Get and set boundary condition."""
-        return self._boundary_condition
-
-    @boundary_condition.setter
-    def boundary_condition(self, bc):
-        assert isinstance(bc, _BoundaryCondition), \
-            'Expected BoundaryCondition not {}'.format(type(bc))
-        self._boundary_condition = bc
-
-    def to_dict(self, include=None):
-        """convert properties to dictionary.
-
-        args:
-            include: A list of keys to be included in dictionary besides face_type
-                and boundary condition. If None all the available keys will be included.
+        Args:
+            host: A honeybee-core geometry object that hosts these properties
+                (ie. Model, Room, Face, Shade, Aperture, Door).
         """
-        base = {
-            'type': 'FaceProperties',
-            'face_type': self.face_type.name
-        }
+        self._host = host
 
+    @property
+    def host(self):
+        """Get the object hosting these properties."""
+        return self._host
+
+    def duplicate_extension_attr(self, original_properties):
+        """Duplicate the attributes added by extensions.
+
+        Args:
+            original_properties: The original property object from which
+                the duplicate object will be derived.
+        """
+        attr = [atr for atr in dir(self)
+                if not atr.startswith('_') and atr != 'host']
+
+        for atr in attr:
+            var = getattr(original_properties, atr)
+            try:
+                setattr(self, atr, var.duplicate(self.host))
+            except AttributeError:
+                pass  # it is not an attribute that can be duplicated
+
+    def _add_extension_attr_to_dict(self, base, abridged, include):
+        """Add attributes for extensions to the base dict."""
         if include is not None:
             attr = include
         else:
-            attr = [atr for atr in dir(self) if not atr.startswith('_')]
+            attr = [atr for atr in dir(self)
+                    if not atr.startswith('_') and atr != 'host']
 
         for atr in attr:
             var = getattr(self, atr)
             if not hasattr(var, 'to_dict'):
                 continue
             try:
-                base.update(var.to_dict())
+                base.update(var.to_dict(abridged))
             except Exception as e:
                 raise Exception(
-                    'Failed to convert {} to a dict: {}'.format(var, e)
-                )
-
-        if 'energy' in base:
-            base['boundary_condition'] = self.boundary_condition.to_dict(full=True)
-        else:
-            base['boundary_condition'] = self.boundary_condition.to_dict(full=False)
+                    'Failed to convert {} to a dict: {}'.format(var, e))
         return base
 
     def ToString(self):
@@ -79,4 +65,203 @@ class Properties(object):
 
     def __repr__(self):
         """Properties representation."""
-        return 'FaceProperties:%s' % str(self.face_type.name)
+        return 'BaseProperties'
+
+
+class ModelProperties(_Properties):
+    """Honeybee Model Properties.
+
+    Model properties. This class will be extended by plugins.
+
+    Usage:
+        model = Model('New Elementary School', list_of_rooms)
+        model.properties -> ModelProperties
+        model.properties.radiance -> ModelRadianceProperties
+        model.properties.energy -> ModelEnergyProperties
+    """
+
+    def to_dict(self, include=None):
+        """Convert properties to dictionary.
+
+        Args:
+            include: A list of keys to be included in dictionary.
+                If None all the available keys will be included.
+        """
+        base = {
+            'type': 'ModelProperties'
+        }
+
+        base = self._add_extension_attr_to_dict(base, False, include)
+        return base
+
+    def __repr__(self):
+        """Properties representation."""
+        return 'ModelProperties'
+
+
+class RoomProperties(_Properties):
+    """Honeybee Room Properties.
+
+    Room properties. This class will be extended by plugins.
+
+    Usage:
+        room = Room('Bedroom', geometry)
+        room.properties -> RoomProperties
+        room.properties.radiance -> RoomRadianceProperties
+        room.properties.energy -> RoomEnergyProperties
+    """
+
+    def to_dict(self, abridged=False, include=None):
+        """Convert properties to dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            include: A list of keys to be included in dictionary.
+                If None all the available keys will be included.
+        """
+        base = {
+            'type': 'RoomProperties'
+        }
+
+        base = self._add_extension_attr_to_dict(base, abridged, include)
+        return base
+
+    def __repr__(self):
+        """Properties representation."""
+        return 'RoomProperties'
+
+
+class FaceProperties(_Properties):
+    """Honeybee Face Properties.
+
+    Face properties. This class will be extended by plugins.
+
+    Usage:
+        face = Face('South Bedroom Wall', geometry)
+        face.properties -> FaceProperties
+        face.properties.radiance -> FaceRadianceProperties
+        face.properties.energy -> FaceEnergyProperties
+    """
+
+    def to_dict(self, abridged=False, include=None):
+        """Convert properties to dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            include: A list of keys to be included in dictionary besides Face type
+                and boundary_condition. If None all the available keys will be included.
+        """
+        base = {
+            'type': 'FaceProperties',
+        }
+        base = self._add_extension_attr_to_dict(base, abridged, include)
+        return base
+
+    def __repr__(self):
+        """Properties representation."""
+        return 'FaceProperties: {}'.format(self.host.name_original)
+
+
+class ShadeProperties(_Properties):
+    """Honeybee Shade Properties.
+
+    Shade properties. This class will be extended by plugins.
+
+    Usage:
+        shade = Shade('Deep Overhang', geometry)
+        shade.properties -> ShadeProperties
+        shade.properties.radiance -> ShadeRadianceProperties
+        shade.properties.energy -> ShadeEnergyProperties
+    """
+
+    def to_dict(self, abridged=False, include=None):
+        """Convert properties to dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            include: A list of keys to be included in dictionary.
+                If None all the available keys will be included.
+        """
+        base = {
+            'type': 'ShadeProperties'
+        }
+
+        base = self._add_extension_attr_to_dict(base, abridged, include)
+        return base
+
+    def __repr__(self):
+        """Properties representation."""
+        return 'ShadeProperties: {}'.format(self.host.name_original)
+
+
+class ApertureProperties(_Properties):
+    """Honeybee Aperture Properties.
+
+    Aperture properties. This class will be extended by plugins.
+
+    Usage:
+        aperture = Aperture('Window to My Soul', geometry)
+        aperture.properties -> ApertureProperties
+        aperture.properties.radiance -> ApertureRadianceProperties
+        aperture.properties.energy -> ApertureEnergyProperties
+    """
+
+    def to_dict(self, abridged=False, include=None):
+        """Convert properties to dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            include: A list of keys to be included in dictionary.
+                If None all the available keys will be included.
+        """
+        base = {
+            'type': 'ApertureProperties',
+        }
+
+        base = self._add_extension_attr_to_dict(base, abridged, include)
+        return base
+
+    def __repr__(self):
+        """Properties representation."""
+        return 'ApertureProperties: {}'.format(self.host.name_original)
+
+
+class DoorProperties(_Properties):
+    """Honeybee Door Properties.
+
+    Door properties. This class will be extended by plugins.
+
+    Usage:
+        door = Door('Front Door', geometry)
+        door.properties -> DoorProperties
+        door.properties.radiance -> DoorRadianceProperties
+        door.properties.energy -> DoorEnergyProperties
+    """
+
+    def to_dict(self, abridged=False, include=None):
+        """Convert properties to dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            include: A list of keys to be included in dictionary.
+                If None all the available keys will be included.
+        """
+        base = {
+            'type': 'DoorProperties'
+        }
+        base = self._add_extension_attr_to_dict(base, abridged, include)
+        return base
+
+    def __repr__(self):
+        """Properties representation."""
+        return 'DoorProperties: {}'.format(self.host.name_original)

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -1,0 +1,675 @@
+# coding: utf-8
+"""Honeybee Room."""
+from .properties import RoomProperties
+from .face import Face
+from .shade import Shade
+from .facetype import get_type_from_normal, Wall, Floor
+from .boundarycondition import get_bc_from_position, Outdoors, Surface
+from .typing import valid_string, float_in_range
+import honeybee.writer as writer
+
+from ladybug_geometry.geometry2d.pointvector import Vector2D
+from ladybug_geometry.geometry3d.pointvector import Vector3D, Point3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.polyface import Polyface3D
+
+import math
+
+
+class Room(object):
+    """A volume enclosed by faces, representing a single room or space.
+
+    Properties:
+        name
+        name_original
+        faces
+        indoor_shades
+        outdoor_shades
+        geometry
+        center
+        volume
+        floor_area
+        exposed_area
+        exterior_wall_area
+        exterior_aperture_area
+        average_floor_height
+    """
+    __slots__ = ('_name', '_name_original', '_geometry', '_faces',
+                 '_indoor_shades', '_outdoor_shades', '_properties')
+
+    def __init__(self, name, faces, tolerance=None, angle_tolerance=None):
+        """A volume enclosed by faces, representing a single room or space.
+
+        Note that, if None is input for tolerance and angle_tolerance, no checks will
+        be performed to determine whether the room is a closed volume and no attempt
+        will be made to flip faces in the event that they are not facing outward from
+        the room volume.  As such, an input tolerance of None is intended for
+        workflows where the solidity of the room volume has been evaluated elsewhere.
+
+        Args:
+            name: Room name. Must be < 100 characters.
+            faces: A list or tuple of honeybee Face objects that together form the
+                closed volume of a room.
+            tolerance: tolerance: The maximum difference between x, y, and z values
+                at which vertices of adjacent facesare considered equivalent. This is
+                used in determining whether the faces form a closed volume. Default
+                is None, which makes no attempt to evaluate whether the Room volume
+                is closed.
+            angle_tolerance: The max angle difference in degrees that vertices are
+                allowed to differ from one another in order to consider them colinear.
+                Default is None, which makes no attempt to evaluate whether the Room
+                volume is closed.
+        """
+        # process the name
+        self._name = valid_string(name, 'honeybee room name')
+        self._name_original = name
+
+        # process the zone volume geometry
+        if not isinstance(faces, tuple):
+            faces = tuple(faces)
+        for face in faces:
+            assert isinstance(face, Face), \
+                'Expected honeybee Face. Got {}'.format(type(face))
+            face._parent = self
+
+        if tolerance is None:
+            self._faces = faces
+            self._geometry = None  # calculated later from faces or added by classmethods
+        else:
+            # try to get a closed volume between the faces
+            room_polyface = Polyface3D.from_faces(
+                tuple(face.geometry for face in faces), tolerance)
+            if not room_polyface.is_solid and angle_tolerance is not None:
+                ang_tol = math.radians(angle_tolerance)
+                room_polyface = room_polyface.merge_overlapping_edges(tolerance, ang_tol)
+            # replace honeybee face geometry with versions that are facing outwards
+            if room_polyface.is_solid:
+                for i, correct_face3d in enumerate(room_polyface.faces):
+                    faces[i]._geometry = correct_face3d
+            self._faces = faces
+            self._geometry = room_polyface
+
+        # initialize empty lists for room-assigned shading
+        self._indoor_shades = []
+        self._outdoor_shades = []
+
+        # initialize properties for extensions
+        self._properties = RoomProperties(self)
+
+    @classmethod
+    def from_polyface3d(cls, name, polyface, roof_angle=30, floor_angle=150,
+                        ground_depth=0):
+        """Initialize a Room from a ladybug_geometry Polyface3D object.
+
+        Args:
+            name: Room name. Must be < 100 characters.
+            polyface: A ladybug_geometry Polyface3D object representing the closed
+                volume of a room. The Polyface3D.is_solid property can be used to
+                determine whether the polyface is a closed solid before input here.
+            roof_angle: Cutting angle for roof from Z axis in degrees. Default: 30.
+            floor_angle: Cutting angle for floor from Z axis in degrees. Default: 150.
+            ground_depth: The Z value above which faces are considered Outdoors
+                instead of Ground. Faces will have a Ground boundary condition if
+                their center point lies at or below this value. Default: 0.
+        """
+        assert isinstance(polyface, Polyface3D), \
+            'Expected ladybug_geometry Polyface3D. Got {}'.format(type(polyface))
+        faces = []
+        for i, face in enumerate(polyface.faces):
+            faces.append(Face('{}_Face{}'.format(name, i), face,
+                              get_type_from_normal(face.normal, roof_angle, floor_angle),
+                              get_bc_from_position(face.boundary, ground_depth)))
+        room = cls(name, faces)
+        room._geometry = polyface
+        return room
+
+    @classmethod
+    def from_box(cls, name, width=3.0, depth=6.0, height=3.2,
+                 orientation_angle=0, origin=Point3D(0, 0, 0)):
+        """Initialize a Room from parameters describing a box.
+
+        The resulting faces of the room will always be ordered as follows:
+        (Bottom, Front, Right, Back, Left, Top) where the front is facing the
+        cardinal direction of the orientation_angle.
+
+        Args:
+            name: Room name. Must be < 100 characters.
+            width: Number for the width of the box (in the X direction). Default: 3.0.
+            depth: Number for the depth of the box (in the Y direction). Default: 6.0.
+            height: Number for the height of the box (in the Z direction). Default: 3.2.
+            orientation_angle: A number between 0 and 360 for the clockwise
+                orientation of the box in degrees.
+                (0 = North, 90 = East, 180 = South, 270 = West)
+            origin: A ladybug_geometry Point3D for the origin of the room.
+        """
+        # create a box Polyface3D
+        x_axis = Vector3D(1, 0, 0)
+        if orientation_angle != 0:
+            angle = -1 * math.radians(
+                float_in_range(orientation_angle, 0, 360, 'orientation_angle'))
+            x_axis = x_axis.rotate_xy(angle)
+        base_plane = Plane(Vector3D(0, 0, 1), origin, x_axis)
+        polyface = Polyface3D.from_box(width, depth, height, base_plane)
+
+        # create the honeybee Faces
+        directions = ('Bottom', 'Front', 'Right', 'Back', 'Left', 'Top')
+        faces = []
+        for face, dir in zip(polyface.faces, directions):
+            faces.append(Face('{}_{}'.format(name, dir), face,
+                              get_type_from_normal(face.normal),
+                              get_bc_from_position(face.boundary)))
+        room = cls(name, faces)
+        room._geometry = polyface
+        return room
+
+    @property
+    def name(self):
+        """The room name (including only legal characters)."""
+        return self._name
+
+    @property
+    def name_original(self):
+        """Original input name by user.
+
+        If there are no illegal characters in name then name and name_original will
+        be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
+        Invalid characters are automatically removed from the original name for
+        compatability with simulation engines.
+        """
+        return self._name_original
+
+    @property
+    def faces(self):
+        """Tuple of all honeybee Faces making up this room volume."""
+        return self._faces
+
+    @property
+    def indoor_shades(self):
+        """Tuple of all indoor shades assigned to this room."""
+        return tuple(self._indoor_shades)
+
+    @property
+    def outdoor_shades(self):
+        """Tuple of all outdoor shades assigned to this room."""
+        return tuple(self._outdoor_shades)
+
+    @property
+    def geometry(self):
+        """A ladybug_geometry Polyface3D object representing the room."""
+        if self._geometry is None:
+            self._geometry = Polyface3D.from_faces(
+                tuple(face.geometry for face in self._faces))
+        return self._geometry
+
+    @property
+    def center(self):
+        """A ladybug_geometry Point3D for the center of the room.
+
+        Note that this is the center of the bounding box around the room geometry
+        and not the volume centroid.
+        """
+        return self.geometry.center
+
+    @property
+    def volume(self):
+        """The volume of the room.
+
+        Note that, if this room faces do not form a closed solid (with all face normals
+        pointing outward), the value of this property will not be accurate.
+        """
+        return self.geometry.volume
+
+    @property
+    def floor_area(self):
+        """The combined area of all room floor faces."""
+        return sum([face.area for face in self._faces if isinstance(face.type, Floor)])
+
+    @property
+    def exposed_area(self):
+        """The combined area of all room faces with outdoor boundary conditions.
+
+        Useful for estimating infiltration, often expressed as a flow per
+        unit exposed envelope area.
+        """
+        return sum([face.area for face in self._faces if
+                    isinstance(face.boundary_condition, Outdoors)])
+
+    @property
+    def exterior_wall_area(self):
+        """The combined area of all exterior walls on the room.
+
+        Useful for calculating glazing ratios.
+        """
+        wall_areas = []
+        for face in self._faces:
+            if isinstance(face.boundary_condition, Outdoors) and \
+                    isinstance(face.type, Wall):
+                wall_areas.append(face.area)
+        return sum(wall_areas)
+
+    @property
+    def exterior_aperture_area(self):
+        """The combined area of all exterior apertures on the room.
+
+        Useful for calculating glazing ratios.
+        """
+        ap_areas = []
+        for face in self._faces:
+            if isinstance(face.boundary_condition, Outdoors) and len(face.apertures) > 0:
+                ap_areas.extend([ap.area for ap in face._apertures])
+        return sum(ap_areas)
+
+    @property
+    def average_floor_height(self):
+        """The height of the room floor averaged over all floor faces in the room.
+
+        Will be None if the room posseses no floors. Resulting value is weighted by
+        the area of each of the floor faces.
+        """
+        heights = 0
+        areas = 0
+        for face in self._faces:
+            if isinstance(face.type, Floor):
+                heights += face.center.z * face.area
+                areas += face.area
+        return heights / areas if areas != 0 else None
+
+    @property
+    def has_parent(self):
+        """Always False as Rooms cannot have parents."""
+        return False
+
+    def average_orientation(self, north_vector=Vector2D(0, 1)):
+        """A number between 0 and 360 for the average orientation of exposed walls.
+
+        0 = North, 90 = East, 180 = South, 270 = West.  Wil be None if the zone has
+        no exterior walls. Resulting value is weighted by the area of each of the
+        wall faces.
+
+        Args:
+            north_vector: A ladybug_geometry Vector2D for the north direction.
+                Default is the Y-axis (0, 1).
+        """
+        orientations = 0
+        areas = 0
+        for face in self._faces:
+            if isinstance(face.type, Wall) and \
+                    isinstance(face.boundary_condition, Outdoors):
+                orientations += face.horizontal_orientation(north_vector) * face.area
+                areas += face.area
+        return orientations / areas if areas != 0 else None
+
+    def clear_shades(self):
+        """Remove all indoor and outdoor shades assigned to this room."""
+        self.clear_indoor_shades()
+        self.clear_outdoor_shades()
+
+    def clear_indoor_shades(self):
+        """Remove all indoor shades assigned to this room."""
+        for shade in self._indoor_shades:
+            shade._parent = None
+        self._indoor_shades = []
+
+    def clear_outdoor_shades(self):
+        """Remove all outdoor shades assigned to this room."""
+        for shade in self._outdoor_shades:
+            shade._parent = None
+        self._outdoor_shades = []
+
+    def add_indoor_shade(self, shade):
+        """Add a Shade object to be added to the indoor of this room.
+
+        Indoor Shade objects can be used to represent furniture, the interior
+        part of light shelves, etc.
+        For representing finely detailed objects like blinds or roller shades,
+        it may be more apprpriate to model them as materials assigned to
+        Aperture properties (like Radiance or Energy materials).
+
+        Args:
+            shade: A Shade object to add to the indoors of this room.
+        """
+        assert isinstance(shade, Shade), \
+            'Expected Shade for indoor_shade. Got {}.'.format(type(shade))
+        shade._parent = self
+        self._indoor_shades.append(shade)
+
+    def add_outdoor_shade(self, shade):
+        """Add an Shade object to the outdoor of this room.
+
+        Exterior Shade objects can be used to represent overhangs, fins, etc.
+        For representing larger shade objects like trees or other buildings,
+        it may be more appropriate to add them to the Model as standalone shades
+        without a specific parent Room since they can shade multiple Rooms at once.
+
+        Args:
+            shade: A shade face to add to the outdoors of this room.
+        """
+        assert isinstance(shade, Shade), \
+            'Expected Shade for outdoor_shade. Got {}.'.format(type(shade))
+        shade._parent = self
+        self._outdoor_shades.append(shade)
+
+    def generate_grid(self, x_dim, y_dim=None, offset=1.0):
+        """Get a list of gridded Mesh3D objects offset from the floors of this room.
+
+        Note that the x_dim and y_dim refer to dimensions within the XY coordinate
+        system of the floor faces's planes. So rotating the planes of the floor faces
+        will result in rotated grid cells.
+
+        Args:
+            x_dim: The x dimension of the grid cells as a number.
+            y_dim: The y dimension of the grid cells as a number. Default is None,
+                which will assume the same cell dimension for y as is set for x.
+            offset: A number for how far to offset the grid from the base face.
+                Default is 1.0, which will not offset the grid to be 1 unit above
+                the floor.
+
+        Usage:
+            room = Room.from_box(3.0, 6.0, 3.2, 180)
+            floor_mesh = room.generate_mesh_grid(0.5, 0.5, 1)
+            test_points = floor_mesh[0].face_centroids
+        """
+        floor_grids = []
+        for face in self._faces:
+            if isinstance(face.type, Floor):
+                floor_grids.append(face.geometry.get_mesh_grid(
+                    x_dim, y_dim, offset, True))
+        return floor_grids
+
+    def move(self, moving_vec):
+        """Move this Room along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the room.
+        """
+        for face in self._faces:
+            face.move(moving_vec)
+        for ishd in self._indoor_shades:
+            ishd.move(moving_vec)
+        for oshd in self._outdoor_shades:
+            oshd.move(moving_vec)
+        if self._geometry is not None:
+            self._geometry = self.geometry.move(moving_vec)
+
+    def rotate(self, axis, angle, origin):
+        """Rotate this Room by a certain angle around an axis and origin.
+
+        Args:
+            axis: A ladybug_geometry Vector3D axis representing the axis of rotation.
+            angle: An angle for rotation in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        for face in self._faces:
+            face.rotate(axis, angle, origin)
+        for ishd in self._indoor_shades:
+            ishd.rotate(axis, angle, origin)
+        for oshd in self._outdoor_shades:
+            oshd.rotate(axis, angle, origin)
+        if self._geometry is not None:
+            self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this Room counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        for face in self._faces:
+            face.rotate_xy(angle, origin)
+        for ishd in self._indoor_shades:
+            ishd.rotate_xy(angle, origin)
+        for oshd in self._outdoor_shades:
+            oshd.rotate_xy(angle, origin)
+        if self._geometry is not None:
+            self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
+
+    def reflect(self, plane):
+        """Reflect this Room across a plane with the input normal vector and origin.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        assert isinstance(plane, Plane), \
+            'Expected ladybug_geometry Plane. Got {}.'.format(type(plane))
+        for face in self._faces:
+            face.reflect(plane)
+        for ishd in self._indoor_shades:
+            ishd.reflect(plane)
+        for oshd in self._outdoor_shades:
+            oshd.reflect(plane)
+        if self._geometry is not None:
+            self._geometry = self.geometry.reflect(plane.n, plane.o)
+
+    def scale(self, factor, origin=None):
+        """Scale this Room by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        for face in self._faces:
+            face.scale(factor, origin)
+        for ishd in self._indoor_shades:
+            ishd.scale(factor, origin)
+        for oshd in self._outdoor_shades:
+            oshd.scale(factor, origin)
+        if self._geometry is not None:
+            self._geometry = self.geometry.scale(factor, origin)
+
+    def check_solid(self, tolerance, angle_tolerance, raise_exception=True):
+        """Check whether the Room is a closed solid to within the input tolerances.
+
+        tolerance: tolerance: The maximum difference between x, y, and z values
+            at which face vertices are considered equivalent. This is used in
+            determining whether the faces form a closed volume.
+        angle_tolerance: The max angle difference in degrees that vertices are
+            allowed to differ from one another in order to consider them colinear.
+        raise_exception: Boolean to note whether a ValueError should be raised
+            if the room geometry does not form a closed solid.
+        """
+        if self._geometry is not None and self.geometry.is_solid:
+            return True
+        face_geometries = tuple(face.geometry for face in self._faces)
+        self._geometry = Polyface3D.from_faces(face_geometries, tolerance)
+        if self.geometry.is_solid:
+            return True
+        ang_tol = math.radians(angle_tolerance)
+        self._geometry = self.geometry.merge_overlapping_edges(tolerance, ang_tol)
+        if self.geometry.is_solid:
+            return True
+        if raise_exception:
+            raise ValueError(
+                'Room "{}" is not closed to within {} tolerance and {} angle '
+                'tolerance.'.format(self.name_original, tolerance, angle_tolerance))
+        return False
+
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check that all of the Room's geometry components are planar.
+
+        This includes all of the Room's Faces, Apertures, Doors and Shades.
+
+        Args:
+            tolerance: The minimum distance between a given vertex and a the
+                object's's plane at which the vertex is said to lie in the plane.
+            raise_exception: Boolean to note whether an ValueError should be
+                raised if a vertex does not lie within the object's plane.
+        """
+        for face in self._faces:
+            if not face.check_planar(tolerance, raise_exception):
+                return False
+            for ap in face._apertures:
+                if not ap.check_planar(tolerance, raise_exception):
+                    return False
+            for dr in face._doors:
+                if not dr.check_planar(tolerance, raise_exception):
+                    return False
+        for ishd in self._indoor_shades:
+            if not ishd.check_planar(tolerance, raise_exception):
+                return False
+        for oshd in self._outdoor_shades:
+            if not oshd.check_planar(tolerance, raise_exception):
+                return False
+        return True
+
+    def check_self_intersecting(self, raise_exception=True):
+        """Check that no edges of the Room's geometry components self-intersect.
+
+        This includes all of the Room's Faces, Apertures, Doors and Shades.
+
+        Args:
+            raise_exception: If True, a ValueError will be raised if an object
+                intersects with itself (like a bowtie). Default: True.
+        """
+        for face in self._faces:
+            if not face.check_self_intersecting(raise_exception):
+                return False
+            for ap in face._apertures:
+                if not ap.check_self_intersecting(raise_exception):
+                    return False
+            for dr in face._doors:
+                if not dr.check_self_intersecting(raise_exception):
+                    return False
+        for ishd in self._indoor_shades:
+            if not ishd.check_self_intersecting(raise_exception):
+                return False
+        for oshd in self._outdoor_shades:
+            if not oshd.check_self_intersecting(raise_exception):
+                return False
+        return True
+
+    def check_non_zero(self, tolerance=0.0001, raise_exception=True):
+        """Check that the Room's geometry components are above a "zero" area tolerance.
+
+        This includes all of the Room's Faces, Apertures, Doors and Shades.
+
+        Args:
+            tolerance: The minimum acceptable area of the object. Default is 0.0001,
+                which is equal to 1 cm2 when model units are meters. This is just
+                above the smalest size that OpenStudio will accept.
+            raise_exception: If True, a ValueError will be raised if the object
+                area is below the tolerance. Default: True.
+        """
+        for face in self._faces:
+            if not face.check_non_zero(tolerance, raise_exception):
+                return False
+            for ap in face._apertures:
+                if not ap.check_non_zero(tolerance, raise_exception):
+                    return False
+            for dr in face._doors:
+                if not dr.check_non_zero(tolerance, raise_exception):
+                    return False
+        for ishd in self._indoor_shades:
+            if not ishd.check_non_zero(tolerance, raise_exception):
+                return False
+        for oshd in self._outdoor_shades:
+            if not oshd.check_non_zero(tolerance, raise_exception):
+                return False
+        return True
+
+    @staticmethod
+    def solve_adjcency(rooms, tolerance):
+        """Solve for all adjacencies between a list of input rooms.
+
+        Args:
+            rooms: A list of rooms for which adjacencies will be solved.
+            tolerance: The minimum difference between the coordinate values of two
+                faces at which they can be considered centered adjacent.
+        """
+        for i, room_1 in enumerate(rooms):
+            try:
+                for room_2 in rooms[i + 1:]:
+                    for face_1 in room_1._faces:
+                        for face_2 in room_2._faces:
+                            if not isinstance(face_2.boundary_condition, Surface):
+                                if face_1.geometry.is_centered_adjacent(
+                                        face_2.geometry, tolerance):
+                                    face_1.set_adjacency(face_2)
+                                    break
+            except IndexError:
+                pass  # we have reached the end of the list of zones
+
+    @property
+    def properties(self):
+        """Room properties, including Radiance, Energy and other properties."""
+        return self._properties
+
+    @property
+    def to(self):
+        """Room writer object.
+
+        Use this method to access Writer class to write the room in other formats.
+
+        Usage:
+            room.to.idf(room) -> idf string.
+            room.to.radiance(room) -> Radiance string.
+        """
+        raise NotImplementedError('Room does not yet support writing to files.')
+        return writer
+
+    def to_dict(self, abridged=False, included_prop=None):
+        """Return Room as a dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            included_prop: List of properties to filter keys that must be included in
+                output dictionary. For example ['energy'] will include 'energy' key if
+                available in properties to_dict. By default all the keys will be
+                included. To exclude all the keys from plugins use an empty list.
+        """
+        base = {
+            'type': self.__class__.__name__,
+            'name': self.name,
+            'name_original': self.name_original,
+            'properties': self.properties.to_dict(abridged, included_prop)
+        }
+        base['faces'] = [f.to_dict(abridged, included_prop) for f in self._faces]
+        if self._indoor_shades != []:
+            base['indoor_shades'] = \
+                [shd.to_dict(abridged, included_prop) for shd in self._indoor_shades]
+        else:
+            base['indoor_shades'] = None
+        if self._outdoor_shades != []:
+            base['outdoor_shades'] = \
+                [shd.to_dict(abridged, included_prop) for shd in self._outdoor_shades]
+        else:
+            base['outdoor_shades'] = None
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def __copy__(self):
+        new_r = Room(self.name_original, tuple(face.duplicate() for face in self._faces))
+        new_r._indoor_shades = [ishd.duplicate() for ishd in self._indoor_shades]
+        new_r._outdoor_shades = [oshd.duplicate() for oshd in self._outdoor_shades]
+        for ishd in new_r._indoor_shades:
+            ishd._parent = new_r
+        for oshd in new_r._outdoor_shades:
+            oshd._parent = new_r
+        new_r._geometry = self._geometry
+        new_r._properties.duplicate_extension_attr(self._properties)
+        return new_r
+
+    def __len__(self):
+        return len(self._faces)
+
+    def __getitem__(self, key):
+        return self._faces[key]
+
+    def __iter__(self):
+        return iter(self._faces)
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return 'Room: %s' % self.name_original

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -1,0 +1,290 @@
+# coding: utf-8
+"""Honeybee Shade."""
+from .properties import ShadeProperties
+from .typing import valid_string
+import honeybee.writer as writer
+
+from ladybug_geometry.geometry3d.pointvector import Point3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.face import Face3D
+
+import math
+
+
+class Shade(object):
+    """A single planar shade.
+
+    Properties:
+        name
+        name_original
+        geometry
+        vertices
+        upper_left_vertices
+        normal
+        center
+        area
+        perimeter
+        parent
+        has_parent
+    """
+    __slots__ = ('_name', '_name_original', '_geometry', '_parent', '_properties')
+
+    def __init__(self, name, geometry):
+        """A single planar shade.
+
+        Args:
+            name: Shade name. Must be < 100 characters.
+            geometry: A ladybug-geometry Face3D.
+        """
+        # process the name
+        self._name = valid_string(name, 'honeybee face name')
+        self._name_original = name
+
+        # process the geometry
+        assert isinstance(geometry, Face3D), \
+            'Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
+        self._geometry = geometry
+        self._parent = None  # _parent will be set when the Shade is added to a Room
+
+        # initialize properties for extensions
+        self._properties = ShadeProperties(self)
+
+    @classmethod
+    def from_vertices(cls, name, vertices):
+        """Create a Shade from vertices with each vertex as an iterable of 3 floats.
+
+        Note that this method is not recommended for a shade with one or more holes
+        since the distinction between hole vertices and boundary vertices cannot
+        be derived from a single list of vertices.
+
+        Args:
+            name: Shade name.
+            vertices: A flattened list of 3 or more vertices as (x, y, z).
+        """
+        geometry = Face3D(tuple(Point3D(*v) for v in vertices))
+        return cls(name, geometry)
+
+    @property
+    def name(self):
+        """The shade name (including only legal characters)."""
+        return self._name
+
+    @property
+    def name_original(self):
+        """Original input name by user.
+
+        If there are no illegal characters in name then name and name_original will
+        be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
+        Invalid characters are automatically removed from the original name for
+        compatability with simulation engines.
+        """
+        return self._name_original
+
+    @property
+    def geometry(self):
+        """A ladybug_geometry Face3D object representing the Shade."""
+        return self._geometry
+
+    @property
+    def vertices(self):
+        """List of vertices for the shade (in counter-clockwise order)."""
+        return self._geometry.vertices
+
+    @property
+    def upper_left_vertices(self):
+        """List of vertices starting from the upper-left corner.
+
+        This property should be used when exporting to EnergyPlus / OpenStudio.
+        """
+        return self._geometry.upper_left_counter_clockwise_vertices
+
+    @property
+    def normal(self):
+        """A ladybug_geometry Vector3D for the direction the shade is pointing.
+        """
+        return self._geometry.normal
+
+    @property
+    def center(self):
+        """A ladybug_geometry Point3D for the center of the shade.
+
+        Note that this is the center of the bounding rectangle around this geometry
+        and not the area centroid.
+        """
+        return self._geometry.center
+
+    @property
+    def area(self):
+        """The area of the shade."""
+        return self._geometry.area
+
+    @property
+    def perimeter(self):
+        """The perimeter of the shade."""
+        return self._geometry.perimeter
+
+    @property
+    def parent(self):
+        """Parent Room if assigned. None if not assigned."""
+        return self._parent
+
+    @property
+    def has_parent(self):
+        """Boolean noting whether this Shade has a parent Room."""
+        return self._parent is not None
+
+    def move(self, moving_vec):
+        """Move this Shade along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the face.
+        """
+        self._geometry = self.geometry.move(moving_vec)
+
+    def rotate(self, axis, angle, origin):
+        """Rotate this Shade by a certain angle around an axis and origin.
+
+        Args:
+            axis: A ladybug_geometry Vector3D axis representing the axis of rotation.
+            angle: An angle for rotation in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
+
+    def rotate_xy(self, angle, origin):
+        """Rotate this Shade counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
+
+    def reflect(self, plane):
+        """Reflect this Shade across a plane with the input normal vector and origin.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        assert isinstance(plane, Plane), \
+            'Expected ladybug_geometry Plane. Got {}.'.format(type(plane))
+        self._geometry = self.geometry.reflect(plane.n, plane.o)
+
+    def scale(self, factor, origin=None):
+        """Scale this Shade by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self._geometry = self.geometry.scale(factor, origin)
+
+    def check_planar(self, tolerance, raise_exception=True):
+        """Check whether all of the Shade's vertices lie within the same plane.
+
+        Args:
+            tolerance: The minimum distance between a given vertex and a the
+                object's's plane at which the vertex is said to lie in the plane.
+            raise_exception: Boolean to note whether an ValueError should be
+                raised if a vertex does not lie within the object's plane.
+        """
+        try:
+            return self.geometry.validate_planarity(tolerance, raise_exception)
+        except ValueError as e:
+            raise ValueError('Shade "{}" is not planar.\n{}'.format(
+                self.name_original, e))
+
+    def check_self_intersecting(self, raise_exception=True):
+        """Check whether the edges of the Shade intersect one another (like a bowtwie).
+
+        Args:
+            raise_exception: If True, a ValueError will be raised if the object
+                intersects with itself. Default: True.
+        """
+        if self.geometry.is_self_intersecting:
+            if raise_exception:
+                raise ValueError('Shade "{}" has self-intersecting edges.'.format(
+                    self.name_original))
+            return False
+        return True
+
+    def check_non_zero(self, tolerance=0.0001, raise_exception=True):
+        """Check whether the area of the Shade is above a certain "zero" tolerance.
+
+        Args:
+            tolerance: The minimum acceptable area of the object. Default is 0.0001,
+                which is equal to 1 cm2 when model units are meters. This is just
+                above the smalest size that OpenStudio will accept.
+            raise_exception: If True, a ValueError will be raised if the object
+                area is below the tolerance. Default: True.
+        """
+        if self.area < tolerance:
+            if raise_exception:
+                raise ValueError(
+                    'Shade "{}" geometry is too small. Area must be at least {}. '
+                    'Got {}.'.format(self.name_original, tolerance, self.area))
+            return False
+        return True
+
+    @property
+    def properties(self):
+        """Shade properties, including Radiance, Energy and other properties."""
+        return self._properties
+
+    @property
+    def to(self):
+        """Shade writer object.
+
+        Use this method to access Writer class to write the shade in different formats.
+
+        Usage:
+            shade.to.idf(shade) -> idf string.
+            shade.to.radiance(shade) -> Radiance string.
+        """
+        raise NotImplementedError('Shade does not yet support writing to files.')
+        return writer
+
+    def to_dict(self, abridged=False, included_prop=None):
+        """Return Shade as a dictionary.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                Default: False.
+            included_prop: List of properties to filter keys that must be included in
+                output dictionary. For example ['energy'] will include 'energy' key if
+                available in properties to_dict. By default all the keys will be
+                included. To exclude all the keys from plugins use an empty list.
+        """
+        base = {
+            'type': self.__class__.__name__,
+            'name': self.name,
+            'name_original': self.name_original,
+            'geometry': self._geometry.to_dict(),
+            'properties': self.properties.to_dict(abridged, included_prop)
+        }
+        if self.parent:
+            base['parent'] = self.parent.name
+        else:
+            base['parent'] = None
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __copy__(self):
+        new_shade = Shade(self.name_original, self.geometry)
+        new_shade._properties.duplicate_extension_attr(self._properties)
+        return new_shade
+
+    def __repr__(self):
+        return 'Shade: %s' % self.name_original

--- a/honeybee/typing.py
+++ b/honeybee/typing.py
@@ -51,7 +51,8 @@ def valid_ep_string(value, input_name=''):
     and ensuring the name is not longer than 100 characters.
     """
     try:
-        val = re.sub(r'[^.\sA-Za-z0-9_-]', '', value)
+        val = ''.join(i for i in value if ord(i) < 128)  # strip out non-ascii
+        val = re.sub(r'[,;!\n\t]', '', val)  # strip out E+ special characters
     except TypeError:
         raise TypeError('Input {} must be a text string. Got {}: {}.'.format(
             input_name, type(value), value))
@@ -130,6 +131,7 @@ def list_with_length(value, length=3, item_type=float, input_name=''):
 
 wrapper = '"' if os.name == 'nt' else '\''
 """String wrapper."""
+
 
 def normpath(value):
     """Normalize path eliminating double slashes, etc and put it in quotes if needed."""

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -1,0 +1,341 @@
+"""Test the Aperture class."""
+from honeybee.aperture import Aperture
+from honeybee.shade import Shade
+from honeybee.boundarycondition import Outdoors
+from honeybee.aperturetype import Window
+
+from ladybug_geometry.geometry3d.face import Face3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+
+import pytest
+
+
+def test_aperture_init():
+    """Test the initialization of Aperture objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    aperture = Aperture('Test Window', Face3D(pts))
+    str(aperture)  # test the string representation
+
+    assert aperture.name == 'TestWindow'
+    assert aperture.name_original == 'Test Window'
+    assert isinstance(aperture.geometry, Face3D)
+    assert len(aperture.vertices) == 4
+    assert aperture.upper_left_vertices[0] == Point3D(5, 0, 3)
+    assert len(aperture.triangulated_mesh3d.faces) == 2
+    assert aperture.normal == Vector3D(0, 1, 0)
+    assert aperture.center == Point3D(2.5, 0, 1.5)
+    assert aperture.area == 15
+    assert aperture.perimeter == 16
+    assert isinstance(aperture.boundary_condition, Outdoors)
+    assert isinstance(aperture.type, Window)
+    assert not aperture.has_parent
+
+
+def test_aperture_from_vertices():
+    """Test the initialization of Aperture objects from vertices."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    aperture = Aperture.from_vertices('Test Window', pts)
+
+    assert aperture.name == 'TestWindow'
+    assert aperture.name_original == 'Test Window'
+    assert isinstance(aperture.geometry, Face3D)
+    assert len(aperture.vertices) == 4
+    assert aperture.upper_left_vertices[0] == Point3D(5, 0, 3)
+    assert len(aperture.triangulated_mesh3d.faces) == 2
+    assert aperture.normal == Vector3D(0, 1, 0)
+    assert aperture.center == Point3D(2.5, 0, 1.5)
+    assert aperture.area == 15
+    assert aperture.perimeter == 16
+    assert isinstance(aperture.boundary_condition, Outdoors)
+    assert isinstance(aperture.type, Window)
+    assert not aperture.has_parent
+
+
+def test_aperture_duplicate():
+    """Test the duplication of Aperture objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    ap_1 = Aperture('Test Window', Face3D(pts))
+    ap_2 = ap_1.duplicate()
+
+    assert ap_1 is not ap_2
+    for i, pt in enumerate(ap_1.vertices):
+        assert pt == ap_2.vertices[i]
+    assert ap_1.name == ap_2.name
+
+    ap_2.move(Vector3D(0, 1, 0))
+    for i, pt in enumerate(ap_1.vertices):
+        assert pt != ap_2.vertices[i]
+
+
+def test_aperture_overhang():
+    """Test the creation of an overhang for Aperture objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 3))
+    pts_3 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 0))
+    aperture_1 = Aperture('Rectangle Window', Face3D(pts_1))
+    aperture_2 = Aperture('Good Triangle Window', Face3D(pts_2))
+    aperture_3 = Aperture('Bad Triangle Window', Face3D(pts_3))
+    overhang_1 = aperture_1.overhang(1, tolerance=0.01)
+    overhang_2 = aperture_2.overhang(1, tolerance=0.01)
+    overhang_3 = aperture_3.overhang(1, tolerance=0.01)
+    assert isinstance(overhang_1, Shade)
+    assert isinstance(overhang_2, Shade)
+    assert overhang_3 is None
+
+
+def test_aperture_fin():
+    """Test the creation of a fins for Aperture objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 3))
+    aperture_1 = Aperture('Rectangle Window', Face3D(pts_1))
+    aperture_2 = Aperture('Triangle Window', Face3D(pts_2))
+    right_fin_1 = aperture_1.right_fin(1, tolerance=0.01)
+    right_fin_2 = aperture_2.right_fin(1, tolerance=0.01)
+    left_fin_1 = aperture_1.left_fin(1, tolerance=0.01)
+    left_fin_2 = aperture_2.left_fin(1, tolerance=0.01)
+    assert isinstance(right_fin_1, Shade)
+    assert right_fin_2 is None
+    assert isinstance(left_fin_1, Shade)
+    assert left_fin_2 is None
+
+
+def test_aperture_extruded_border():
+    """Test the creation of an extruded border for Aperture objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 3))
+    aperture_1 = Aperture('Rectangle Window', Face3D(pts_1))
+    aperture_2 = Aperture('Triangle Window', Face3D(pts_2))
+
+    border_1_out = aperture_1.extruded_border(0.1)
+    border_2_out = aperture_2.extruded_border(0.1)
+    border_1_in = aperture_1.extruded_border(0.1, True)
+    border_2_in = aperture_2.extruded_border(0.1, True)
+
+    assert len(border_1_out) == 4
+    assert border_1_out[0].center.y > 0
+    assert len(border_2_out) == 3
+    assert border_2_out[0].center.y > 0
+    assert len(border_1_in) == 4
+    assert border_1_in[0].center.y < 0
+    assert len(border_2_in) == 3
+    assert border_2_in[0].center.y < 0
+
+
+def test_aperture_louvers_by_distance_between():
+    """Test the creation of a louvers_by_distance_between for Aperture objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    aperture = Aperture('Rectangle Window', Face3D(pts_1))
+    louvers = aperture.louvers_by_distance_between(0.5, 0.2, 0.1)
+
+    assert len(louvers) == 6
+    for louver in louvers:
+        assert isinstance(louver, Shade)
+        assert louver.area == 5 * 0.2
+
+
+def test_move():
+    """Test the Aperture move method."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
+    aperture = Aperture('Rectangle Window', Face3D(pts_1, plane_1))
+
+    vec_1 = Vector3D(2, 2, 2)
+    new_ap = aperture.duplicate()
+    new_ap.move(vec_1)
+    assert new_ap.geometry[0] == Point3D(2, 2, 2)
+    assert new_ap.geometry[1] == Point3D(4, 2, 2)
+    assert new_ap.geometry[2] == Point3D(4, 4, 2)
+    assert new_ap.geometry[3] == Point3D(2, 4, 2)
+    assert new_ap.normal == aperture.normal
+    assert aperture.area == new_ap.area
+    assert aperture.perimeter == new_ap.perimeter
+
+
+def test_scale():
+    """Test the Aperture scale method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    aperture = Aperture('Rectangle Window', Face3D(pts, plane))
+
+    new_ap = aperture.duplicate()
+    new_ap.scale(2)
+    assert new_ap.geometry[0] == Point3D(2, 2, 4)
+    assert new_ap.geometry[1] == Point3D(4, 2, 4)
+    assert new_ap.geometry[2] == Point3D(4, 4, 4)
+    assert new_ap.geometry[3] == Point3D(2, 4, 4)
+    assert new_ap.area == aperture.area * 2 ** 2
+    assert new_ap.perimeter == aperture.perimeter * 2
+    assert new_ap.normal == aperture.normal
+
+
+def test_rotate():
+    """Test the Aperture rotate method."""
+    pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    aperture = Aperture('Rectangle Window', Face3D(pts, plane))
+    origin = Point3D(0, 0, 0)
+    axis = Vector3D(1, 0, 0)
+
+    test_1 = aperture.duplicate()
+    test_1.rotate(axis, 180, origin)
+    assert test_1.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(-2, rel=1e-3)
+    assert aperture.area == test_1.area
+    assert len(aperture.vertices) == len(test_1.vertices)
+
+    test_2 = aperture.duplicate()
+    test_2.rotate(axis, 90, origin)
+    assert test_2.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[0].z == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[2].z == pytest.approx(2, rel=1e-3)
+    assert aperture.area == test_2.area
+    assert len(aperture.vertices) == len(test_2.vertices)
+
+
+def test_rotate_xy():
+    """Test the Aperture rotate_xy method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    aperture = Aperture('Rectangle Window', Face3D(pts, plane))
+    origin_1 = Point3D(1, 1, 0)
+
+    test_1 = aperture.duplicate()
+    test_1.rotate_xy(180, origin_1)
+    assert test_1.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = aperture.duplicate()
+    test_2.rotate_xy(90, origin_1)
+    assert test_2.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+
+def test_reflect():
+    """Test the Aperture reflect method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    aperture = Aperture('Rectangle Window', Face3D(pts, plane))
+
+    origin_1 = Point3D(1, 0, 2)
+    origin_2 = Point3D(0, 0, 2)
+    normal_1 = Vector3D(1, 0, 0)
+    normal_2 = Vector3D(-1, -1, 0).normalize()
+    plane_1 = Plane(normal_1, origin_1)
+    plane_2 = Plane(normal_2, origin_2)
+    plane_3 = Plane(normal_2, origin_1)
+
+    test_1 = aperture.duplicate()
+    test_1.reflect(plane_1)
+    assert test_1.geometry[-1].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_1 = aperture.duplicate()
+    test_1.reflect(plane_2)
+    assert test_1.geometry[-1].x == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = aperture.duplicate()
+    test_2.reflect(plane_3)
+    assert test_2.geometry[-1].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].y == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[1].x == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].y == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+
+def test_check_planar():
+    """Test the check_planar method."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_3 = (Point3D(0, 0, 2.0001), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    aperture_1 = Aperture('Window 1', Face3D(pts_1, plane_1))
+    aperture_2 = Aperture('Window 2', Face3D(pts_2, plane_1))
+    aperture_3 = Aperture('Window 3', Face3D(pts_3, plane_1))
+
+    assert aperture_1.check_planar(0.001) is True
+    assert aperture_2.check_planar(0.001, False) is False
+    with pytest.raises(Exception):
+        aperture_2.check_planar(0.0001)
+    assert aperture_3.check_planar(0.001) is True
+    assert aperture_3.check_planar(0.000001, False) is False
+    with pytest.raises(Exception):
+        aperture_3.check_planar(0.000001)
+
+
+def test_check_self_intersecting():
+    """Test the check_self_intersecting method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    plane_2 = Plane(Vector3D(0, 0, -1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))
+    pts_2 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 0), Point3D(2, 2))
+    aperture_1 = Aperture('Window 1', Face3D(pts_1, plane_1))
+    aperture_2 = Aperture('Window 2', Face3D(pts_2, plane_1))
+    aperture_3 = Aperture('Window 3', Face3D(pts_1, plane_2))
+    aperture_4 = Aperture('Window 4', Face3D(pts_2, plane_2))
+
+    assert aperture_1.check_self_intersecting(False) is True
+    assert aperture_2.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert aperture_2.check_self_intersecting(True)
+    assert aperture_3.check_self_intersecting(False) is True
+    assert aperture_4.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert aperture_4.check_self_intersecting(True)
+
+
+def test_check_non_zero():
+    """Test the check_non_zero method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2))
+    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 0))
+    aperture_1 = Aperture('Window 1', Face3D(pts_1, plane_1))
+    aperture_2 = Aperture('Window 2', Face3D(pts_2, plane_1))
+
+    assert aperture_1.check_non_zero(0.0001, False) is True
+    assert aperture_2.check_non_zero(0.0001, False) is False
+    with pytest.raises(Exception):
+        assert aperture_2.check_self_intersecting(0.0001, True)
+
+
+def test_to_dict():
+    """Test the Aperture to_dict method."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    ap = Aperture.from_vertices('Rectangle Window', vertices)
+
+    ad = ap.to_dict()
+    assert ad['type'] == 'Aperture'
+    assert ad['name'] == 'RectangleWindow'
+    assert ad['name_original'] == 'Rectangle Window'
+    assert 'geometry' in ad
+    assert len(ad['geometry']['boundary']) == len(vertices)
+    assert 'properties' in ad
+    assert ad['properties']['type'] == 'ApertureProperties'
+    assert ad['aperture_type']['type'] == 'Window'
+    assert ad['boundary_condition']['type'] == 'Outdoors'
+    assert ad['parent'] is None

--- a/tests/aperturetype_test.py
+++ b/tests/aperturetype_test.py
@@ -1,0 +1,13 @@
+"""test Face class."""
+from honeybee.aperturetype import Window, aperture_types
+
+import pytest
+
+
+def test_wall():
+    """Test the initialization of the Window aperture type."""
+    window_type_1 = Window()
+    window_type_2 = aperture_types.window
+
+    str(window_type_1)  # test the string representation
+    assert window_type_1 == window_type_2

--- a/tests/boundary_condition_test.py
+++ b/tests/boundary_condition_test.py
@@ -1,6 +1,7 @@
 """test Face class."""
 from honeybee.boundarycondition import boundary_conditions
 from honeybee.face import Face
+
 import pytest
 
 bcs = boundary_conditions
@@ -9,19 +10,16 @@ bcs = boundary_conditions
 def test_outdoors():
     bc = bcs.outdoors
     assert bc.name == 'Outdoors'
-    assert bc.sun_exposure == True
+    assert bc.sun_exposure
     assert bc.sun_exposure_idf == 'SunExposed'
-    assert bc.wind_exposure == True
+    assert bc.wind_exposure
     assert bc.wind_exposure_idf == 'WindExposed'
-    assert bc.boundary_condition_object == None
-    assert bc.boundary_condition_object_idf == ''
 
 
 def test_outdoors_to_dict():
     bc = bcs.outdoors
     outdict = bc.to_dict(full=True)
-    assert outdict['name'] == 'Outdoors'
-    assert outdict['bc_object'] == ''
+    assert outdict['type'] == 'Outdoors'
     assert outdict['sun_exposure'] == 'SunExposed'
     assert outdict['wind_exposure'] == 'WindExposed'
     assert outdict['view_factor'] == 'autocalculate'
@@ -34,12 +32,10 @@ def test_outdoors_to_dict():
 def test_ground():
     bc = bcs.ground
     assert bc.name == 'Ground'
-    assert bc.sun_exposure == False
+    assert not bc.sun_exposure
     assert bc.sun_exposure_idf == 'NoSun'
-    assert bc.wind_exposure == False
+    assert not bc.wind_exposure
     assert bc.wind_exposure_idf == 'NoWind'
-    assert bc.boundary_condition_object == None
-    assert bc.boundary_condition_object_idf == ''
 
 
 def test_surface():
@@ -47,9 +43,8 @@ def test_surface():
     face = Face.from_vertices('wall', vertices)
     bc = bcs.surface(face)
     assert bc.name == 'Surface'
-    assert bc.sun_exposure == False
+    assert not bc.sun_exposure
     assert bc.sun_exposure_idf == 'NoSun'
-    assert bc.wind_exposure == False
+    assert not bc.wind_exposure
     assert bc.wind_exposure_idf == 'NoWind'
-    assert bc.boundary_condition_object.name == face.name
-    assert bc.boundary_condition_object_idf == face.name
+    assert bc.boundary_condition_object == face.name

--- a/tests/door_test.py
+++ b/tests/door_test.py
@@ -1,0 +1,270 @@
+"""Test the Door class."""
+from honeybee.door import Door
+from honeybee.boundarycondition import Outdoors
+
+from ladybug_geometry.geometry3d.face import Face3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+
+import pytest
+
+
+def test_door_init():
+    """Test the initialization of Door objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    door = Door('Test Door', Face3D(pts))
+    str(door)  # test the string representation
+
+    assert door.name == 'TestDoor'
+    assert door.name_original == 'Test Door'
+    assert isinstance(door.geometry, Face3D)
+    assert len(door.vertices) == 4
+    assert door.upper_left_vertices[0] == Point3D(1, 0, 3)
+    assert len(door.triangulated_mesh3d.faces) == 2
+    assert door.normal == Vector3D(0, 1, 0)
+    assert door.center == Point3D(0.5, 0, 1.5)
+    assert door.area == 3
+    assert door.perimeter == 8
+    assert isinstance(door.boundary_condition, Outdoors)
+    assert not door.has_parent
+
+
+def test_door_from_vertices():
+    """Test the initialization of Door objects from vertices."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    door = Door.from_vertices('Test Door', pts)
+
+    assert door.name == 'TestDoor'
+    assert door.name_original == 'Test Door'
+    assert isinstance(door.geometry, Face3D)
+    assert len(door.vertices) == 4
+    assert door.upper_left_vertices[0] == Point3D(1, 0, 3)
+    assert len(door.triangulated_mesh3d.faces) == 2
+    assert door.normal == Vector3D(0, 1, 0)
+    assert door.center == Point3D(0.5, 0, 1.5)
+    assert door.area == 3
+    assert door.perimeter == 8
+    assert isinstance(door.boundary_condition, Outdoors)
+    assert not door.has_parent
+
+
+def test_door_duplicate():
+    """Test the duplication of door objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    dr_1 = Door('Test Door', Face3D(pts))
+    dr_2 = dr_1.duplicate()
+
+    assert dr_1 is not dr_2
+    for i, pt in enumerate(dr_1.vertices):
+        assert pt == dr_2.vertices[i]
+    assert dr_1.name == dr_2.name
+
+    dr_2.move(Vector3D(0, 1, 0))
+    for i, pt in enumerate(dr_1.vertices):
+        assert pt != dr_2.vertices[i]
+
+
+def test_move():
+    """Test the Door move method."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
+    door = Door('Rectangle Door', Face3D(pts_1, plane_1))
+
+    vec_1 = Vector3D(2, 2, 2)
+    new_dr = door.duplicate()
+    new_dr.move(vec_1)
+    assert new_dr.geometry[0] == Point3D(2, 2, 2)
+    assert new_dr.geometry[1] == Point3D(4, 2, 2)
+    assert new_dr.geometry[2] == Point3D(4, 4, 2)
+    assert new_dr.geometry[3] == Point3D(2, 4, 2)
+    assert new_dr.normal == door.normal
+    assert door.area == new_dr.area
+    assert door.perimeter == new_dr.perimeter
+
+
+def test_scale():
+    """Test the Door scale method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    door = Door('Rectangle Door', Face3D(pts, plane))
+
+    new_dr = door.duplicate()
+    new_dr.scale(2)
+    assert new_dr.geometry[0] == Point3D(2, 2, 4)
+    assert new_dr.geometry[1] == Point3D(4, 2, 4)
+    assert new_dr.geometry[2] == Point3D(4, 4, 4)
+    assert new_dr.geometry[3] == Point3D(2, 4, 4)
+    assert new_dr.area == door.area * 2 ** 2
+    assert new_dr.perimeter == door.perimeter * 2
+    assert new_dr.normal == door.normal
+
+
+def test_rotate():
+    """Test the Door rotate method."""
+    pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    door = Door('Rectangle Door', Face3D(pts, plane))
+    origin = Point3D(0, 0, 0)
+    axis = Vector3D(1, 0, 0)
+
+    test_1 = door.duplicate()
+    test_1.rotate(axis, 180, origin)
+    assert test_1.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(-2, rel=1e-3)
+    assert door.area == test_1.area
+    assert len(door.vertices) == len(test_1.vertices)
+
+    test_2 = door.duplicate()
+    test_2.rotate(axis, 90, origin)
+    assert test_2.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[0].z == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[2].z == pytest.approx(2, rel=1e-3)
+    assert door.area == test_2.area
+    assert len(door.vertices) == len(test_2.vertices)
+
+
+def test_rotate_xy():
+    """Test the Door rotate_xy method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    door = Door('Rectangle Door', Face3D(pts, plane))
+    origin_1 = Point3D(1, 1, 0)
+
+    test_1 = door.duplicate()
+    test_1.rotate_xy(180, origin_1)
+    assert test_1.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = door.duplicate()
+    test_2.rotate_xy(90, origin_1)
+    assert test_2.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+
+def test_reflect():
+    """Test the Door reflect method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    door = Door('Rectangle Door', Face3D(pts, plane))
+
+    origin_1 = Point3D(1, 0, 2)
+    origin_2 = Point3D(0, 0, 2)
+    normal_1 = Vector3D(1, 0, 0)
+    normal_2 = Vector3D(-1, -1, 0).normalize()
+    plane_1 = Plane(normal_1, origin_1)
+    plane_2 = Plane(normal_2, origin_2)
+    plane_3 = Plane(normal_2, origin_1)
+
+    test_1 = door.duplicate()
+    test_1.reflect(plane_1)
+    assert test_1.geometry[-1].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_1 = door.duplicate()
+    test_1.reflect(plane_2)
+    assert test_1.geometry[-1].x == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = door.duplicate()
+    test_2.reflect(plane_3)
+    assert test_2.geometry[-1].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].y == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[1].x == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].y == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+
+def test_check_planar():
+    """Test the check_planar method."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_3 = (Point3D(0, 0, 2.0001), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    door_1 = Door('Door 1', Face3D(pts_1, plane_1))
+    door_2 = Door('Door 2', Face3D(pts_2, plane_1))
+    door_3 = Door('Door 3', Face3D(pts_3, plane_1))
+
+    assert door_1.check_planar(0.001) is True
+    assert door_2.check_planar(0.001, False) is False
+    with pytest.raises(Exception):
+        door_2.check_planar(0.0001)
+    assert door_3.check_planar(0.001) is True
+    assert door_3.check_planar(0.000001, False) is False
+    with pytest.raises(Exception):
+        door_3.check_planar(0.000001)
+
+
+def test_check_self_intersecting():
+    """Test the check_self_intersecting method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    plane_2 = Plane(Vector3D(0, 0, -1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))
+    pts_2 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 0), Point3D(2, 2))
+    door_1 = Door('Door 1', Face3D(pts_1, plane_1))
+    door_2 = Door('Door 2', Face3D(pts_2, plane_1))
+    door_3 = Door('Door 3', Face3D(pts_1, plane_2))
+    door_4 = Door('Door 4', Face3D(pts_2, plane_2))
+
+    assert door_1.check_self_intersecting(False) is True
+    assert door_2.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert door_2.check_self_intersecting(True)
+    assert door_3.check_self_intersecting(False) is True
+    assert door_4.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert door_4.check_self_intersecting(True)
+
+
+def test_check_non_zero():
+    """Test the check_non_zero method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2))
+    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 0))
+    door_1 = Door('Door 1', Face3D(pts_1, plane_1))
+    door_2 = Door('Door 2', Face3D(pts_2, plane_1))
+
+    assert door_1.check_non_zero(0.0001, False) is True
+    assert door_2.check_non_zero(0.0001, False) is False
+    with pytest.raises(Exception):
+        assert door_2.check_self_intersecting(0.0001, True)
+
+
+def test_to_dict():
+    """Test the Door to_dict method."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    dr = Door.from_vertices('Rectangle Door', vertices)
+
+    drd = dr.to_dict()
+    assert drd['type'] == 'Door'
+    assert drd['name'] == 'RectangleDoor'
+    assert drd['name_original'] == 'Rectangle Door'
+    assert 'geometry' in drd
+    assert len(drd['geometry']['boundary']) == len(vertices)
+    assert 'properties' in drd
+    assert drd['properties']['type'] == 'DoorProperties'
+    assert drd['boundary_condition']['type'] == 'Outdoors'
+    assert drd['parent'] is None

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -1,63 +1,584 @@
-"""test Face class."""
+"""Test Face class."""
 from honeybee.face import Face
-from honeybee.properties import face_types as Types
-from honeybee.boundarycondition import boundary_conditions
+from honeybee.facetype import face_types, Wall
+from honeybee.boundarycondition import boundary_conditions, Outdoors
+from honeybee.aperture import Aperture
+from honeybee.door import Door
+from honeybee.shade import Shade
+
+from ladybug_geometry.geometry3d.face import Face3D
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.plane import Plane
+
 import pytest
 
 
-def test_name():
-    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
-    f = Face.from_vertices('Wall: SIM_INT_AIR [920980]', vertices)
-    assert f.name == 'WallSIM_INT_AIR920980'
-    assert f.name_original == 'Wall: SIM_INT_AIR [920980]'
+def test_init():
+    """Test the initialization of a Face."""
+    vertices = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    face = Face('Wall: SIM_INT_AIR [920980]', Face3D(vertices))
+
+    assert face.name == 'WallSIM_INT_AIR920980'
+    assert face.name_original == 'Wall: SIM_INT_AIR [920980]'
+    assert isinstance(face.geometry, Face3D)
+    assert len(face.vertices) == 4
+    assert face.upper_left_vertices[0] == Point3D(0, 0, 3)
+    assert face.normal == Vector3D(1, 0, 0)
+    assert face.center == Point3D(0, 5, 1.5)
+    assert face.area == 30
+    assert face.perimeter == 26
+    assert isinstance(face.boundary_condition, Outdoors)
+    assert isinstance(face.type, Wall)
+    assert not face.has_parent
 
 
-def test_vertices_count():
-    with pytest.raises(Exception):
-        Face.from_vertices('no vertices', [], Types.wall)
-
-
-def test_type_from_vertices():
+def test_default_face_type():
+    """Test the auto-assigning of face type by normal."""
     vertices_wall = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
     vertices_floor = [[0, 0, 0], [0, 10, 0], [10, 10, 0], [10, 0, 0]]
     vertices_roof = list(reversed(vertices_floor))
 
     wf = Face.from_vertices('wall', vertices_wall)
-    assert wf.properties.face_type == wf.properties.TYPES.wall
-
+    assert wf.type == wf.TYPES.wall
     rf = Face.from_vertices('roof', vertices_roof)
-    assert rf.properties.face_type == rf.properties.TYPES.roof_ceiling
-
+    assert rf.type == rf.TYPES.roof_ceiling
     ff = Face.from_vertices('floor', vertices_floor)
-    assert ff.properties.face_type == ff.properties.TYPES.floor
+    assert ff.type == ff.TYPES.floor
+
+
+def test_setting_face_type():
+    """Test the setting of face type to override default."""
+    vertices = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    face = Face('Vertical Roof', Face3D(vertices), face_types.roof_ceiling)
+
+    assert face.type == face_types.roof_ceiling
+    face.type = face_types.wall
+    assert face.type == face_types.wall
 
 
 def test_default_boundary_condition():
-    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
-    face = Face.from_vertices('wall', vertices)
-    assert face.boundary_condition == boundary_conditions.outdoors
+    """Test the auto-assigning of face boundary condition by normal."""
+    vertices_above = \
+        [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    vertices_mid = \
+        [Point3D(0, 0, -1), Point3D(0, 10, -1), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    vertices_below = \
+        [Point3D(0, 0, -3), Point3D(0, 10, -3), Point3D(0, 10, 0), Point3D(0, 0, 0)]
+    face_above = Face('Wall Above', Face3D(vertices_above))
+    face_mid = Face('Wall Mid', Face3D(vertices_mid))
+    face_below = Face('Wall Below', Face3D(vertices_below))
+
+    assert face_above.boundary_condition == boundary_conditions.outdoors
+    assert face_mid.boundary_condition == boundary_conditions.outdoors
+    assert face_below.boundary_condition == boundary_conditions.ground
 
 
 def test_set_boundary_condition():
-    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
-    face = Face.from_vertices('wall', vertices, Types.wall, boundary_conditions.ground)
-    assert face.boundary_condition == boundary_conditions.ground
+    """Test the setting of boundary condition to override default."""
+    vertices = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    face = Face('Wall', Face3D(vertices), face_types.wall, boundary_conditions.ground)
 
+    assert face.boundary_condition == boundary_conditions.ground
     face.boundary_condition = boundary_conditions.outdoors
     assert face.boundary_condition == boundary_conditions.outdoors
 
 
+def test_face_duplicate():
+    """Test the duplication of Face objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    face_1 = Aperture('Test Face', Face3D(pts))
+    face_2 = face_1.duplicate()
+
+    assert face_1 is not face_2
+    for i, pt in enumerate(face_1.vertices):
+        assert pt == face_2.vertices[i]
+    assert face_1.name == face_2.name
+
+    face_2.move(Vector3D(0, 1, 0))
+    for i, pt in enumerate(face_1.vertices):
+        assert pt != face_2.vertices[i]
+
+
+def test_horizontal_orientation():
+    """Test the Face horizontal_orientation method."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0)]
+    pts_2 = tuple(reversed(pts_1))
+    pts_3 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 5, 3), Point3D(0, 5, 0)]
+    pts_4 = tuple(reversed(pts_3))
+
+    face_1 = Face('Test Face', Face3D(pts_1))
+    face_2 = Face('Test Face', Face3D(pts_2))
+    face_3 = Face('Test Face', Face3D(pts_3))
+    face_4 = Face('Test Face', Face3D(pts_4))
+
+    assert face_1.horizontal_orientation() == 0
+    assert face_2.horizontal_orientation() == 180
+    assert face_3.horizontal_orientation() == 270
+    assert face_4.horizontal_orientation() == 90
+
+
+def test_cardinal_direction():
+    """Test the Face cardinal_direction method."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0)]
+    pts_2 = tuple(reversed(pts_1))
+    pts_3 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 5, 3), Point3D(0, 5, 0)]
+    pts_4 = tuple(reversed(pts_3))
+
+    face_1 = Face('Test Face', Face3D(pts_1))
+    face_2 = Face('Test Face', Face3D(pts_2))
+    face_3 = Face('Test Face', Face3D(pts_3))
+    face_4 = Face('Test Face', Face3D(pts_4))
+
+    assert face_1.cardinal_direction() == 'North'
+    assert face_2.cardinal_direction() == 'South'
+    assert face_3.cardinal_direction() == 'West'
+    assert face_4.cardinal_direction() == 'East'
+
+
+def test_add_remove_door():
+    """Test the adding and removing of an door to a Face."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    face = Face('Test_Roof', face_face3d)
+    door = Door('Test_Trap_Door', ap_face3d)
+    face.add_door(door)
+
+    assert len(face.doors) == 1
+    assert len(face.doors[0].geometry.vertices) == 4
+    assert face.doors[0].area == pytest.approx(4, rel=1e-2)
+    assert face.doors[0].parent is face
+    assert len(face.punched_vertices) == 10
+    assert face.punched_geometry.area == 96
+    assert face.check_doors_valid(0.01, 1)
+
+    face.clear_doors()
+    assert len(face.doors) == 0
+    assert len(face.punched_vertices) == 4
+    assert face.punched_geometry.area == 100
+
+
+def test_add_remove_doors():
+    """Test the adding and removing of multiple doors to a Face."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d_1 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    ap_face3d_2 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 3)))
+    face = Face('Test_Roof', face_face3d)
+    door_1 = Door('Test_Trap_Door_1', ap_face3d_1)
+    door_2 = Door('Test_Trap_Door_2', ap_face3d_2)
+    face.add_doors([door_1, door_2])
+
+    assert len(face.doors) == 2
+    assert face.doors[0].parent is face
+    assert face.doors[1].parent is face
+    assert len(face.punched_vertices) == 16
+    assert face.punched_geometry.area == 92
+    assert face.check_doors_valid(0.01, 1)
+
+    face.clear_doors()
+    assert len(face.doors) == 0
+    assert len(face.punched_vertices) == 4
+    assert face.punched_geometry.area == 100
+
+
+def test_add_remove_aperture():
+    """Test the adding and removing of an aperture to a Face."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    face = Face('Test_Roof', face_face3d)
+    aperture = Aperture('Test_Skylight', ap_face3d)
+    face.add_aperture(aperture)
+
+    assert len(face.apertures) == 1
+    assert len(face.apertures[0].geometry.vertices) == 4
+    assert face.apertures[0].area == pytest.approx(4, rel=1e-2)
+    assert face.apertures[0].parent is face
+    assert len(face.punched_vertices) == 10
+    assert face.punched_geometry.area == 96
+    assert face.check_apertures_valid(0.01, 1)
+
+    face.clear_apertures()
+    assert len(face.apertures) == 0
+    assert len(face.punched_vertices) == 4
+    assert face.punched_geometry.area == 100
+
+
+def test_add_remove_apertures():
+    """Test the adding and removing of multiple apertures to a Face."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d_1 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    ap_face3d_2 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 3)))
+    face = Face('Test_Roof', face_face3d)
+    aperture_1 = Aperture('Test_Skylight_1', ap_face3d_1)
+    aperture_2 = Aperture('Test_Skylight_2', ap_face3d_2)
+    face.add_apertures([aperture_1, aperture_2])
+
+    assert len(face.apertures) == 2
+    assert face.apertures[0].parent is face
+    assert face.apertures[1].parent is face
+    assert len(face.punched_vertices) == 16
+    assert face.punched_geometry.area == 92
+    assert face.check_apertures_valid(0.01, 1)
+
+    face.clear_apertures()
+    assert len(face.apertures) == 0
+    assert len(face.punched_vertices) == 4
+    assert face.punched_geometry.area == 100
+
+
+def test_add_remove_sub_faces():
+    """Test the adding and removing of an aperture and a door to a Face."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    dr_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 3)))
+    face = Face('Test_Roof', face_face3d)
+    aperture = Aperture('Test_Skylight', ap_face3d)
+    door = Door('Test_Trap_Door', dr_face3d)
+    face.add_aperture(aperture)
+    face.add_door(door)
+
+    assert len(face.apertures) == 1
+    assert len(face.doors) == 1
+    assert face.apertures[0].parent is face
+    assert face.doors[0].parent is face
+    assert len(face.punched_vertices) == 16
+    assert face.punched_geometry.area == 92
+    assert face.check_sub_faces_valid(0.01, 1)
+
+    face.clear_sub_faces()
+    assert len(face.apertures) == 0
+    assert len(face.punched_vertices) == 4
+    assert face.punched_geometry.area == 100
+
+
+def test_sub_faces_invalid():
+    """Test the adding and removing of invalid sub-faces."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    dr_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 3)))
+    dr_face3d_invalid_1 = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 1)))
+    dr_face3d_invalid_2 = \
+        Face3D([Point3D(0, 0, 0), Point3D(0, 1, 0), Point3D(0, 1, 3), Point3D(0, 0, 3)])
+
+    face = Face('Test_Roof', face_face3d)
+    aperture = Aperture('Test_Skylight', ap_face3d)
+    door = Door('Test_Trap_Door', dr_face3d)
+    invalid_aperture_1 = Aperture('Test_Skylight', dr_face3d_invalid_1)
+    invalid_aperture_2 = Aperture('Test_Skylight', dr_face3d_invalid_2)
+
+    with pytest.raises(AssertionError):
+        face.add_aperture(door)
+    with pytest.raises(AssertionError):
+        face.add_door(aperture)
+
+    face.add_aperture(invalid_aperture_1)
+    with pytest.raises(ValueError):
+        face.check_apertures_valid(0.01, 1)
+    face.clear_apertures()
+
+    face.add_aperture(invalid_aperture_2)
+    with pytest.raises(ValueError):
+        face.check_apertures_valid(0.01, 1)
+
+
+def test_sub_faces_invalid_boundary_condition():
+    """Test the adding of a sub-face to a face with invalid boundary conditions."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    dr_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 3)))
+
+    face = Face('Test_Roof', face_face3d, face_types.wall, boundary_conditions.ground)
+    aperture = Aperture('Test_Skylight', ap_face3d)
+    door = Door('Test_Trap_Door', dr_face3d)
+
+    with pytest.raises(AssertionError):
+        face.add_aperture(aperture)
+    with pytest.raises(AssertionError):
+        face.add_door(door)
+
+
+def test_sub_faces_invalid_face_type():
+    """Test the adding of a sub-face to a face with invalid face type."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    dr_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(7, 7, 3)))
+
+    face = Face('Test_Roof', face_face3d, face_types.air_wall)
+    aperture = Aperture('Test_Skylight', ap_face3d)
+    door = Door('Test_Trap_Door', dr_face3d)
+
+    with pytest.raises(AssertionError):
+        face.add_aperture(aperture)
+    with pytest.raises(AssertionError):
+        face.add_door(door)
+
+
+def test_apertures_by_ratio():
+    """Test the adding of apertures by ratio."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    face = Face('Test_Wall', Face3D(pts))
+    face.apertures_by_ratio(0.4, 0.01)
+
+    assert len(face.apertures) == 1
+    assert len(face.apertures[0].geometry.vertices) == 4
+    assert sum([ap.area for ap in face.apertures]) == pytest.approx(15 * 0.4, rel=1e-2)
+    assert face.punched_geometry.area == pytest.approx(15 * 0.6, rel=1e-2)
+
+
+def test_apertures_by_ratio_rectangle():
+    """Test the adding of apertures by ratio with rectangle apertures."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    face = Face('Test_Wall', Face3D(pts))
+    face.apertures_by_ratio_rectangle(0.4, 2, 0.7, 1.5, 0, 0.01)
+
+    assert len(face.apertures) == 3
+    assert len(face.apertures[0].geometry.vertices) == 4
+    assert sum([ap.area for ap in face.apertures]) == pytest.approx(15 * 0.4, rel=1e-2)
+    assert face.punched_geometry.area == pytest.approx(15 * 0.6, rel=1e-2)
+    assert face.apertures[0].geometry.min.z == 0.7
+    assert face.apertures[0].geometry.max.z - face.apertures[0].geometry.min.z == 2
+
+
+def test_apertures_by_width_height():
+    """Test the adding of apertures by width and height."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    face = Face('Test_Wall', Face3D(pts))
+    face.aperture_by_width_height(4, 2, 0.7)
+
+    assert len(face.apertures) == 1
+    assert len(face.apertures[0].geometry.vertices) == 4
+    assert face.apertures[0].area == pytest.approx(8, rel=1e-2)
+
+
+def test_face_overhang():
+    """Test the creation of an overhang for Face objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 3))
+    pts_3 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 0))
+    face_1 = Face('Rectangle Face', Face3D(pts_1))
+    face_2 = Face('Good Triangle Face', Face3D(pts_2))
+    face_3 = Face('Bad Triangle Face', Face3D(pts_3))
+    overhang_1 = face_1.overhang(1, tolerance=0.01)
+    overhang_2 = face_2.overhang(1, tolerance=0.01)
+    overhang_3 = face_3.overhang(1, tolerance=0.01)
+    assert isinstance(overhang_1, Shade)
+    assert isinstance(overhang_2, Shade)
+    assert overhang_3 is None
+
+
+def test_face_louvers_by_distance_between():
+    """Test the creation of a louvers_by_distance_between for Face objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    aperture = Face('Rectangle Face', Face3D(pts_1))
+    louvers = aperture.louvers_by_distance_between(0.5, 0.2, 0.1)
+
+    assert len(louvers) == 6
+    for louver in louvers:
+        assert isinstance(louver, Shade)
+        assert louver.area == 5 * 0.2
+
+
+def test_move():
+    """Test the Face move method."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
+    face = Face('Rectangle Face', Face3D(pts_1, plane_1))
+
+    vec_1 = Vector3D(2, 2, 2)
+    new_f = face.duplicate()
+    new_f.move(vec_1)
+    assert new_f.geometry[0] == Point3D(2, 2, 2)
+    assert new_f.geometry[1] == Point3D(4, 2, 2)
+    assert new_f.geometry[2] == Point3D(4, 4, 2)
+    assert new_f.geometry[3] == Point3D(2, 4, 2)
+    assert new_f.normal == face.normal
+    assert face.area == new_f.area
+    assert face.perimeter == new_f.perimeter
+
+
+def test_scale():
+    """Test the Face scale method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    face = Face('Rectangle Face', Face3D(pts, plane))
+
+    new_f = face.duplicate()
+    new_f.scale(2)
+    assert new_f.geometry[0] == Point3D(2, 2, 4)
+    assert new_f.geometry[1] == Point3D(4, 2, 4)
+    assert new_f.geometry[2] == Point3D(4, 4, 4)
+    assert new_f.geometry[3] == Point3D(2, 4, 4)
+    assert new_f.area == face.area * 2 ** 2
+    assert new_f.perimeter == face.perimeter * 2
+    assert new_f.normal == face.normal
+
+
+def test_rotate():
+    """Test the Face rotate method."""
+    pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    face = Face('Rectangle Face', Face3D(pts, plane))
+    origin = Point3D(0, 0, 0)
+    axis = Vector3D(1, 0, 0)
+
+    test_1 = face.duplicate()
+    test_1.rotate(axis, 180, origin)
+    assert test_1.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(-2, rel=1e-3)
+    assert face.area == test_1.area
+    assert len(face.vertices) == len(test_1.vertices)
+
+    test_2 = face.duplicate()
+    test_2.rotate(axis, 90, origin)
+    assert test_2.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[0].z == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[2].z == pytest.approx(2, rel=1e-3)
+    assert face.area == test_2.area
+    assert len(face.vertices) == len(test_2.vertices)
+
+
+def test_rotate_xy():
+    """Test the Face rotate_xy method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    face = Face('Rectangle Face', Face3D(pts, plane))
+    origin_1 = Point3D(1, 1, 0)
+
+    test_1 = face.duplicate()
+    test_1.rotate_xy(180, origin_1)
+    assert test_1.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = face.duplicate()
+    test_2.rotate_xy(90, origin_1)
+    assert test_2.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+
+def test_reflect():
+    """Test the Face reflect method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    face = Face('Rectangle Face', Face3D(pts, plane))
+
+    origin_1 = Point3D(1, 0, 2)
+    origin_2 = Point3D(0, 0, 2)
+    normal_1 = Vector3D(1, 0, 0)
+    normal_2 = Vector3D(-1, -1, 0).normalize()
+    plane_1 = Plane(normal_1, origin_1)
+    plane_2 = Plane(normal_2, origin_2)
+    plane_3 = Plane(normal_2, origin_1)
+
+    test_1 = face.duplicate()
+    test_1.reflect(plane_1)
+    assert test_1.geometry[-1].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_1 = face.duplicate()
+    test_1.reflect(plane_2)
+    assert test_1.geometry[-1].x == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = face.duplicate()
+    test_2.reflect(plane_3)
+    assert test_2.geometry[-1].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].y == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[1].x == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].y == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+
+def test_check_planar():
+    """Test the check_planar method."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_3 = (Point3D(0, 0, 2.0001), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    face_1 = Face('Wall 1', Face3D(pts_1, plane_1))
+    face_2 = Face('Wall 2', Face3D(pts_2, plane_1))
+    face_3 = Face('Wall 3', Face3D(pts_3, plane_1))
+
+    assert face_1.check_planar(0.001) is True
+    assert face_2.check_planar(0.001, False) is False
+    with pytest.raises(Exception):
+        face_2.check_planar(0.0001)
+    assert face_3.check_planar(0.001) is True
+    assert face_3.check_planar(0.000001, False) is False
+    with pytest.raises(Exception):
+        face_3.check_planar(0.000001)
+
+
+def test_check_self_intersecting():
+    """Test the check_self_intersecting method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    plane_2 = Plane(Vector3D(0, 0, -1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))
+    pts_2 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 0), Point3D(2, 2))
+    face_1 = Face('Wall 1', Face3D(pts_1, plane_1))
+    face_2 = Face('Wall 2', Face3D(pts_2, plane_1))
+    face_3 = Face('Wall 3', Face3D(pts_1, plane_2))
+    face_4 = Face('Wall 4', Face3D(pts_2, plane_2))
+
+    assert face_1.check_self_intersecting(False) is True
+    assert face_2.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert face_2.check_self_intersecting(True)
+    assert face_3.check_self_intersecting(False) is True
+    assert face_4.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert face_4.check_self_intersecting(True)
+
+
+def test_check_non_zero():
+    """Test the check_non_zero method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2))
+    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 0))
+    face_1 = Face('Wall 1', Face3D(pts_1, plane_1))
+    face_2 = Face('Wall 2', Face3D(pts_2, plane_1))
+
+    assert face_1.check_non_zero(0.0001, False) is True
+    assert face_2.check_non_zero(0.0001, False) is False
+    with pytest.raises(Exception):
+        assert face_2.check_self_intersecting(0.0001, True)
+
+
 def test_to_dict():
+    """Test the Face to_dict method."""
     vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
-    face = Face.from_vertices('wall', vertices, Types.wall, boundary_conditions.ground)
-    
-    fd = face.to_dict([])
+    face = Face.from_vertices('test wall', vertices, face_types.wall,
+                              boundary_conditions.ground)
+
+    fd = face.to_dict()
     assert fd['type'] == 'Face'
-    assert fd['name'] == 'wall'
-    assert 'vertices' in fd
-    assert len(fd['vertices']) == len(vertices)
+    assert fd['name'] == 'testwall'
+    assert fd['name_original'] == 'test wall'
+    assert 'geometry' in fd
+    assert len(fd['geometry']['boundary']) == len(vertices)
     assert 'properties' in fd
     assert fd['properties']['type'] == 'FaceProperties'
-    assert fd['properties']['face_type'] == 'Wall'
-    assert fd['properties']['boundary_condition']['name'] == 'Ground'
-    assert fd['properties']['boundary_condition']['bc_object'] == ''
+    assert fd['face_type']['type'] == 'Wall'
+    assert fd['boundary_condition']['type'] == 'Ground'

--- a/tests/facetype_test.py
+++ b/tests/facetype_test.py
@@ -1,0 +1,44 @@
+"""test Face class."""
+from honeybee.facetype import Wall, RoofCeiling, Floor, AirWall, face_types
+
+import pytest
+
+
+def test_wall():
+    """Test the initialization of the Wall face type."""
+    wall_type_1 = Wall()
+    wall_type_2 = face_types.wall
+
+    str(wall_type_1)  # test the string representation
+    assert wall_type_1 == wall_type_2
+    assert wall_type_1 != face_types.floor
+
+
+def test_roof_ceiling():
+    """Test the initialization of the RoofCeiling face type."""
+    roof_type_1 = RoofCeiling()
+    roof_type_2 = face_types.roof_ceiling
+
+    str(roof_type_1)  # test the string representation
+    assert roof_type_1 == roof_type_2
+    assert roof_type_1 != face_types.floor
+
+
+def test_floor():
+    """Test the initialization of the Floor face type."""
+    floor_type_1 = Floor()
+    floor_type_2 = face_types.floor
+
+    str(floor_type_1)  # test the string representation
+    assert floor_type_1 == floor_type_2
+    assert floor_type_1 != face_types.wall
+
+
+def test_air_wall():
+    """Test the initialization of the AirWall face type."""
+    air_type_1 = AirWall()
+    air_type_2 = face_types.air_wall
+
+    str(air_type_1)  # test the string representation
+    assert air_type_1 == air_type_2
+    assert air_type_1 != face_types.wall

--- a/tests/lockable_test.py
+++ b/tests/lockable_test.py
@@ -1,0 +1,142 @@
+"""Test locakble decorator."""
+from honeybee._lockable import lockable
+
+import pytest
+
+
+def test_simple_class():
+    """Test the application of the lockable decorator to a simple class."""
+    @lockable
+    class Foo(object):
+        def __init__(self):
+            self.bar = 10
+
+    foo = Foo()
+    foo.bar = 20
+    print(hasattr(foo, '__slots__'))
+
+    foo.lock()
+    with pytest.raises(AttributeError):
+        foo.bar = 30
+
+    foo.unlock()
+    foo.bar = 30
+    assert foo.bar == 30
+    foo.lock()
+
+
+def test_nested_classes():
+    """Test lockable decorator with nested classes, which are not locked by default."""
+    @lockable
+    class Material(object):
+        def __init__(self):
+            self.r_value = 3
+
+    @lockable
+    class Construction(object):
+        def __init__(self):
+            self.material = Material()
+
+    constr = Construction()
+    constr.lock()
+    with pytest.raises(AttributeError):
+        constr.material = Material()
+
+    constr.material.r_value = 5
+    constr.material.lock()
+    with pytest.raises(AttributeError):
+        constr.material.r_value = 10
+
+
+def test_custom_lock_method():
+    """Test the lockable decorator with a custom lock() method to lock nested classes."""
+    @lockable
+    class Material(object):
+        def __init__(self):
+            self.r_value = 3
+
+    @lockable
+    class Construction(object):
+        def __init__(self):
+            self.material = Material()
+
+        def lock(self):
+            self._locked = True
+            self.material._locked = True
+
+        def unlock(self):
+            self._locked = False
+            self.material._locked = False
+
+    constr = Construction()
+    constr.lock()
+    with pytest.raises(AttributeError):
+        constr.material = Material()
+
+    with pytest.raises(AttributeError):
+        constr.material.r_value = 5
+
+    constr.unlock()
+    constr.material = Material()
+    constr.material.r_value = 5
+    constr.lock()
+
+
+def test_with_slots():
+    """Test the application of the lockable decorator to a class with __slots__."""
+    @lockable
+    class Foo(object):
+        __slots__ = ('bar', '_locked')
+
+        def __init__(self):
+            self.bar = 10
+
+    foo = Foo()
+    foo.bar = 20
+
+    foo.lock()
+    with pytest.raises(AttributeError):
+        foo.bar = 30
+
+    foo.unlock()
+    foo.bar = 30
+    foo.lock()
+
+
+def test_with_slots_incorrect():
+    """Test the lockable decorator on a class with an incorrect use of __slots__."""
+    with pytest.raises(AttributeError):
+        @lockable
+        class Foo(object):
+            __slots__ = ('bar',)
+
+            def __init__(self):
+                self.bar = 10
+
+
+def test_with_slots_inheritance():
+    """Test the lockable decorator for a class with __slots__ and inheritance."""
+    @lockable
+    class Bar(object):
+        __slots__ = ('_locked',)
+
+        def __init__(self):
+            pass
+
+    @lockable
+    class Foo(Bar):
+        __slots__ = ('bar',)
+
+        def __init__(self):
+            self.bar = 10
+
+    foo = Foo()
+    foo.bar = 20
+
+    foo.lock()
+    with pytest.raises(AttributeError):
+        foo.bar = 30
+
+    foo.unlock()
+    foo.bar = 30
+    foo.lock()

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -1,0 +1,472 @@
+"""test Zone class."""
+from honeybee.face import Face
+from honeybee.room import Room
+from honeybee.boundarycondition import boundary_conditions, Surface
+
+from ladybug_geometry.geometry2d.pointvector import Vector2D
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.face import Face3D
+from ladybug_geometry.geometry3d.polyface import Polyface3D
+
+import pytest
+
+
+def test_init():
+    """Test the initialization of a room and basic properties."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1))
+    face_2 = Face('Face 2', Face3D(pts_2))
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4))
+    face_5 = Face('Face 5', Face3D(pts_5))
+    face_6 = Face('Face 6', Face3D(pts_6))
+    room = Room('Zone: SHOE_BOX [920980]',
+                [face_1, face_2, face_3, face_4, face_5, face_6], 0.01, 1)
+
+    str(room)  # test the string representation of the room
+    assert room.name == 'ZoneSHOE_BOX920980'
+    assert room.name_original == 'Zone: SHOE_BOX [920980]'
+    assert isinstance(room.geometry, Polyface3D)
+    assert len(room.geometry.vertices) == 8
+    assert len(room) == 6
+    assert room.center == Point3D(5, 5, 1.5)
+    assert room.volume == 300
+    assert room.floor_area == 100
+    assert room.exposed_area == 220
+    assert room.exterior_wall_area == 120
+    assert room.exterior_aperture_area == 0
+    assert room.average_floor_height == 0
+    assert not room.has_parent
+    assert room.check_solid(0.01, 1)
+
+    assert room[0].normal == Vector3D(0, 0, -1)
+    assert room[1].normal == Vector3D(-1, 0, 0)
+    assert room[2].normal == Vector3D(0, -1, 0)
+    assert room[3].normal == Vector3D(0, 1, 0)
+    assert room[4].normal == Vector3D(1, 0, 0)
+    assert room[5].normal == Vector3D(0, 0, 1)
+
+
+def test_init_open():
+    """Test the initialization of a room with open geometry."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 2.5, 3), Point3D(0, 2.5, 3), Point3D(0, 0, 3)]
+    pts_7 = [Point3D(10, 2.5, 3), Point3D(10, 5, 3), Point3D(0, 5, 3), Point3D(0, 2.5, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1))
+    face_2 = Face('Face 2', Face3D(pts_2))
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4))
+    face_5 = Face('Face 5', Face3D(pts_5))
+    face_6 = Face('Face 6', Face3D(pts_6))
+    face_7 = Face('Face 7', Face3D(pts_7))
+    room = Room('Zone: SHOE_BOX [920980]',
+                [face_1, face_2, face_3, face_4, face_5, face_6, face_7],
+                0.01, 1)
+
+    assert not room.check_solid(0.01, 1, False)
+    with pytest.raises(ValueError):
+        room.check_solid(0.01, 1, True)
+
+
+def test_init_coplanar():
+    """Test the initialization of a room with coplanar faces."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 2.5, 3), Point3D(0, 2.5, 3), Point3D(0, 0, 3)]
+    pts_7 = [Point3D(10, 2.5, 3), Point3D(10, 5, 3), Point3D(0, 5, 3), Point3D(0, 2.5, 3)]
+    pts_8 = [Point3D(10, 5, 3), Point3D(10, 10, 3), Point3D(0, 10, 3), Point3D(0, 5, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1))
+    face_2 = Face('Face 2', Face3D(pts_2))
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4))
+    face_5 = Face('Face 5', Face3D(pts_5))
+    face_6 = Face('Face 6', Face3D(pts_6))
+    face_7 = Face('Face 7', Face3D(pts_7))
+    face_8 = Face('Face 8', Face3D(pts_8))
+    room = Room('Zone: SHOE_BOX [920980]',
+                [face_1, face_2, face_3, face_4, face_5, face_6, face_7, face_8],
+                0.01, 1)
+
+    str(room)  # test the string representation of the room
+    assert room.name == 'ZoneSHOE_BOX920980'
+    assert room.name_original == 'Zone: SHOE_BOX [920980]'
+    assert isinstance(room.geometry, Polyface3D)
+    assert len(room.geometry.vertices) == 12
+    assert len(room) == 8
+    assert room.center == Point3D(5, 5, 1.5)
+    assert room.volume == 300
+    assert room.floor_area == 100
+    assert room.exposed_area == 220
+    assert room.exterior_wall_area == 120
+    assert room.exterior_aperture_area == 0
+    assert room.average_floor_height == 0
+    assert not room.has_parent
+    assert room.check_solid(0.01, 1)
+
+
+def test_polyface3d_init_from_polyface():
+    """Test the initalization of room from a Poyface3D."""
+    bound_pts = [Point3D(0, 0), Point3D(3, 0), Point3D(3, 3), Point3D(0, 3)]
+    hole_pts = [Point3D(1, 1, 0), Point3D(2, 1, 0), Point3D(2, 2, 0), Point3D(1, 2, 0)]
+    face = Face3D(bound_pts, None, [hole_pts])
+    polyface = Polyface3D.from_offset_face(face, 3)
+    room = Room.from_polyface3d('Donut Zone', polyface)
+
+    assert room.name == 'DonutZone'
+    assert room.name_original == 'Donut Zone'
+    assert isinstance(room.geometry, Polyface3D)
+    assert len(room.geometry.vertices) == 16
+    assert len(room) == 10
+    assert room.center == Point3D(1.5, 1.5, 1.5)
+    assert room.volume == 24
+    assert room.floor_area == 8
+    assert room.exposed_area == 56
+    assert room.exterior_wall_area == 48
+    assert room.exterior_aperture_area == 0
+    assert room.average_floor_height == 0
+    assert not room.has_parent
+    assert room.check_solid(0.01, 1)
+
+
+def test_init_from_box():
+    """Test the initialization of a room from box."""
+    room = Room.from_box('Zone: SHOE_BOX [920980]', 5, 10, 3, 90, Point3D(0, 0, 3))
+
+    assert room.name == 'ZoneSHOE_BOX920980'
+    assert room.name_original == 'Zone: SHOE_BOX [920980]'
+    assert isinstance(room.geometry, Polyface3D)
+    assert len(room.geometry.vertices) == 8
+    assert len(room) == 6
+    assert room.center.x == pytest.approx(5, rel=1e-3)
+    assert room.center.y == pytest.approx(-2.5, rel=1e-3)
+    assert room.center.z == pytest.approx(4.5, rel=1e-3)
+    assert room.volume == 150
+    assert room.floor_area == 50
+    assert room.exposed_area == 190
+    assert room.exterior_wall_area == 90
+    assert room.exterior_aperture_area == 0
+    assert room.average_floor_height == 3
+    assert not room.has_parent
+    assert room.check_solid(0.01, 1)
+
+
+def test_average_orientation():
+    """Test the average orientation method."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1), boundary_condition=boundary_conditions.ground)
+    face_2 = Face('Face 2', Face3D(pts_2), boundary_condition=boundary_conditions.ground)
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4), boundary_condition=boundary_conditions.ground)
+    face_5 = Face('Face 5', Face3D(pts_5), boundary_condition=boundary_conditions.ground)
+    face_6 = Face('Face 6', Face3D(pts_6))
+    room = Room('PAssive Solar Earthship',
+                [face_1, face_2, face_3, face_4, face_5, face_6], 0.01, 1)
+
+    assert room.average_orientation() == 180
+    assert room.average_orientation(Vector2D(1, 0)) == 90
+
+
+def test_apertures_and_shades():
+    """Test the addition of apertures and shades to a room."""
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3)
+    south_face = room[3]
+    south_face.apertures_by_ratio(0.5, 0.01)
+    room.add_outdoor_shade(south_face.overhang(0.5, indoor=False))
+    room.add_indoor_shade(south_face.overhang(0.5, indoor=True))
+
+    assert room.exterior_aperture_area == pytest.approx(7.5, rel=1e-3)
+    assert len(room.indoor_shades) == 1
+    assert len(room.outdoor_shades) == 1
+    assert room.indoor_shades[0].parent == room
+    assert room.outdoor_shades[0].parent == room
+    room.clear_indoor_shades()
+    assert len(room.indoor_shades) == 0
+    room.clear_outdoor_shades()
+    assert len(room.outdoor_shades) == 0
+
+    room.add_outdoor_shade(south_face.overhang(0.5, indoor=False))
+    room.add_indoor_shade(south_face.overhang(0.5, indoor=True))
+    assert len(room.indoor_shades) == 1
+    assert len(room.outdoor_shades) == 1
+    room.clear_shades()
+    assert len(room.indoor_shades) == 0
+    assert len(room.outdoor_shades) == 0
+
+
+def test_generate_grid():
+    """Test the generate_grid method."""
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3)
+    mesh_grid = room.generate_grid(1)[0]
+    assert len(mesh_grid.faces) == 50
+    mesh_grid = room.generate_grid(0.5)[0]
+    assert len(mesh_grid.faces) == 200
+
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3, 90)
+    mesh_grid = room.generate_grid(1)[0]
+    assert len(mesh_grid.faces) == 50
+
+
+def test_move():
+    """Test the Room move method."""
+    room = Room.from_box('ShoeBoxZone', 2, 2, 2)
+
+    vec_1 = Vector3D(2, 2, 2)
+    new_room = room.duplicate()
+    new_room.move(vec_1)
+    assert new_room.geometry.vertices[0] == Point3D(2, 2, 2)
+    assert new_room.geometry.vertices[1] == Point3D(2, 4, 2)
+    assert new_room.geometry.vertices[2] == Point3D(4, 4, 2)
+    assert new_room.geometry.vertices[3] == Point3D(4, 2, 2)
+
+    assert room.floor_area == new_room.floor_area
+    assert room.volume == new_room.volume
+
+
+def test_scale():
+    """Test the Room scale method with None origin."""
+    room = Room.from_box('ShoeBoxZone', 1, 1, 1, origin=Point3D(1, 1, 2))
+
+    new_room = room.duplicate()
+    new_room.scale(2)
+    assert new_room.geometry.vertices[0] == Point3D(2, 2, 4)
+    assert new_room.geometry.vertices[1] == Point3D(2, 4, 4)
+    assert new_room.geometry.vertices[2] == Point3D(4, 4, 4)
+    assert new_room.geometry.vertices[3] == Point3D(4, 2, 4)
+    assert new_room.floor_area == room.floor_area * 2 ** 2
+    assert new_room.volume == room.volume * 2 ** 3
+
+
+def test_rotate():
+    """Test the Room rotate method."""
+    room = Room.from_box('ShoeBoxZone', 2, 2, 2, origin=Point3D(0, 0, 2))
+    origin = Point3D(0, 0, 0)
+    axis = Vector3D(1, 0, 0)
+
+    test_1 = room.duplicate()
+    test_1.rotate(axis, 180, origin)
+    assert test_1.geometry.vertices[0].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry.vertices[0].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry.vertices[0].z == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry.vertices[2].x == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry.vertices[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry.vertices[2].z == pytest.approx(-2, rel=1e-3)
+    assert room.floor_area == test_1.floor_area
+    assert room.volume == test_1.volume
+    assert len(room.geometry.vertices) == len(test_1.geometry.vertices)
+
+    test_2 = room.duplicate()
+    test_2.rotate(axis, 90, origin)
+    assert test_2.geometry.vertices[0].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry.vertices[0].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry.vertices[0].z == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry.vertices[2].x == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry.vertices[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry.vertices[2].z == pytest.approx(2, rel=1e-3)
+    assert room.floor_area == test_2.floor_area
+    assert room.volume == test_1.volume
+    assert len(room.geometry.vertices) == len(test_2.geometry.vertices)
+
+
+def test_rotate_xy():
+    """Test the Room rotate_xy method."""
+    room = Room.from_box('ShoeBoxZone', 1, 1, 1, origin=Point3D(1, 1, 2))
+    origin_1 = Point3D(1, 1, 0)
+
+    test_1 = room.duplicate()
+    test_1.rotate_xy(180, origin_1)
+    assert test_1.geometry.vertices[0].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry.vertices[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry.vertices[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry.vertices[2].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry.vertices[2].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry.vertices[2].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = room.duplicate()
+    room.rotate_xy(90, origin_1)
+    assert test_2.geometry.vertices[0].x == pytest.approx(1, rel=1e-3)
+    assert test_2.geometry.vertices[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry.vertices[0].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry.vertices[2].x == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry.vertices[2].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry.vertices[2].z == pytest.approx(2, rel=1e-3)
+
+
+def test_reflect():
+    """Test the Room reflect method."""
+    room = Room.from_box('ShoeBoxZone', 1, 1, 1, origin=Point3D(1, 1, 2))
+
+    origin_1 = Point3D(1, 0, 2)
+    normal_1 = Vector3D(1, 0, 0)
+    normal_2 = Vector3D(-1, -1, 0).normalize()
+
+    test_1 = room.duplicate()
+    test_1.reflect(Plane(normal_1, origin_1))
+    assert test_1.geometry.vertices[0].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry.vertices[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry.vertices[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry.vertices[2].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry.vertices[2].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry.vertices[2].z == pytest.approx(2, rel=1e-3)
+
+    test_1 = room.duplicate()
+    test_1.reflect(Plane(normal_2, Point3D(0, 0, 2)))
+    assert test_1.geometry.vertices[0].x == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry.vertices[0].y == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry.vertices[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry.vertices[2].x == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry.vertices[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry.vertices[2].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = room.duplicate()
+    test_2.reflect(Plane(normal_2, origin_1))
+    assert test_2.geometry.vertices[0].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry.vertices[0].y == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry.vertices[0].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry.vertices[2].x == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry.vertices[2].y == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry.vertices[2].z == pytest.approx(2, rel=1e-3)
+
+
+def test_check_planar():
+    """Test the check_planar method."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    pts_7 = [Point3D(10, 0, 3), Point3D(10, 10, 3.1), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1))
+    face_2 = Face('Face 2', Face3D(pts_2))
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4))
+    face_5 = Face('Face 5', Face3D(pts_5))
+    face_6 = Face('Face 6', Face3D(pts_6))
+    face_7 = Face('Face 7', Face3D(pts_7))
+    room_1 = Room('Zone: SHOE_BOX [920980]',
+                  [face_1, face_2, face_3, face_4, face_5, face_6], 0.01, 1)
+    room_2 = Room('Zone: SHOE_BOX [920980]',
+                  [face_1, face_2, face_3, face_4, face_5, face_7], 0.01, 1)
+
+    assert room_1.check_planar(0.01, False)
+    assert not room_2.check_planar(0.01, False)
+
+
+def test_check_self_intersecting():
+    """Test the check_self_intersecting method."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    pts_7 = [Point3D(10, 0, 3), Point3D(0, 10, 3), Point3D(10, 10, 3), Point3D(0, 0, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1))
+    face_2 = Face('Face 2', Face3D(pts_2))
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4))
+    face_5 = Face('Face 5', Face3D(pts_5))
+    face_6 = Face('Face 6', Face3D(pts_6))
+    face_7 = Face('Face 7', Face3D(pts_7))
+    room_1 = Room('Zone: SHOE_BOX [920980]',
+                  [face_1, face_2, face_3, face_4, face_5, face_6], 0.01, 1)
+    room_2 = Room('Zone: SHOE_BOX [920980]',
+                  [face_1, face_2, face_3, face_4, face_5, face_7], 0.01, 1)
+
+    assert room_1.check_self_intersecting(False)
+    assert not room_2.check_self_intersecting(False)
+
+
+def test_check_non_zero():
+    """Test the check_non_zero method."""
+    pts_1 = [Point3D(0, 0, 0), Point3D(0, 10, 0), Point3D(10, 10, 0), Point3D(10, 0, 0)]
+    pts_2 = [Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(0, 10, 3), Point3D(0, 10, 0)]
+    pts_3 = [Point3D(0, 0, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(0, 0, 3)]
+    pts_4 = [Point3D(10, 10, 0), Point3D(0, 10, 0), Point3D(0, 10, 3), Point3D(10, 10, 3)]
+    pts_5 = [Point3D(10, 10, 0), Point3D(10, 0, 0), Point3D(10, 0, 3), Point3D(10, 10, 3)]
+    pts_6 = [Point3D(10, 0, 3), Point3D(10, 10, 3), Point3D(0, 10, 3), Point3D(0, 0, 3)]
+    pts_7 = [Point3D(10, 0, 3), Point3D(10, 0.0001, 3), Point3D(0, 0.0001, 3), Point3D(0, 0, 3)]
+    face_1 = Face('Face 1', Face3D(pts_1))
+    face_2 = Face('Face 2', Face3D(pts_2))
+    face_3 = Face('Face 3', Face3D(pts_3))
+    face_4 = Face('Face 4', Face3D(pts_4))
+    face_5 = Face('Face 5', Face3D(pts_5))
+    face_6 = Face('Face 6', Face3D(pts_6))
+    face_7 = Face('Face 7', Face3D(pts_7))
+    room_1 = Room('Zone: SHOE_BOX [920980]',
+                  [face_1, face_2, face_3, face_4, face_5, face_6], 0.01, 1)
+    room_2 = Room('Zone: SHOE_BOX [920980]',
+                  [face_1, face_2, face_3, face_4, face_5, face_6, face_7])
+
+    assert room_1.check_non_zero(0.01, False)
+    assert not room_2.check_non_zero(0.01, False)
+
+
+def test_solve_adjacency():
+    """Test the solve adjacency method."""
+    room_south = Room.from_box('South Zone', 5, 5, 3, origin=Point3D(0, 0, 0))
+    room_north = Room.from_box('North Zone', 5, 5, 3, origin=Point3D(0, 5, 0))
+
+    assert room_south[1].boundary_condition == boundary_conditions.outdoors
+    assert room_north[3].boundary_condition == boundary_conditions.outdoors
+
+    Room.solve_adjcency([room_south, room_north], 0.01)
+
+    assert isinstance(room_south[1].boundary_condition, Surface)
+    assert isinstance(room_north[3].boundary_condition, Surface)
+    assert room_south[1].boundary_condition.boundary_condition_object == room_north[3].name
+    assert room_north[3].boundary_condition.boundary_condition_object == room_south[1].name
+
+
+def test_solve_adjacency_aperture():
+    """Test the solve adjacency method with an interior aperture."""
+    room_south = Room.from_box('South Zone', 5, 5, 3, origin=Point3D(0, 0, 0))
+    room_north = Room.from_box('North Zone', 5, 5, 3, origin=Point3D(0, 5, 0))
+    room_south[1].apertures_by_ratio(0.4, 0.01)
+    room_north[3].apertures_by_ratio(0.4, 0.01)
+
+    assert room_south[1].apertures[0].boundary_condition == boundary_conditions.outdoors
+    assert room_north[3].apertures[0].boundary_condition == boundary_conditions.outdoors
+
+    Room.solve_adjcency([room_south, room_north], 0.01)
+
+    assert isinstance(room_south[1].apertures[0].boundary_condition, Surface)
+    assert isinstance(room_north[3].apertures[0].boundary_condition, Surface)
+    assert room_south[1].apertures[0].boundary_condition.boundary_condition_object == \
+        room_north[3].apertures[0].name
+    assert room_north[3].apertures[0].boundary_condition.boundary_condition_object == \
+        room_south[1].apertures[0].name
+
+
+def test_to_dict():
+    """Test the Room to_dict method."""
+    room = Room.from_box('Shoe Box Zone', 5, 10, 3)
+
+    rd = room.to_dict()
+    assert rd['type'] == 'Room'
+    assert rd['name'] == 'ShoeBoxZone'
+    assert rd['name_original'] == 'Shoe Box Zone'
+    assert 'faces' in rd
+    assert len(rd['faces']) == 6
+    assert rd['indoor_shades'] is None
+    assert rd['outdoor_shades'] is None
+    assert 'properties' in rd
+    assert rd['properties']['type'] == 'RoomProperties'

--- a/tests/shade_test.py
+++ b/tests/shade_test.py
@@ -1,0 +1,264 @@
+"""Test the Shade class."""
+from honeybee.shade import Shade
+
+from ladybug_geometry.geometry3d.face import Face3D
+from ladybug_geometry.geometry3d.plane import Plane
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+
+import pytest
+
+
+def test_shade_init():
+    """Test the initialization of Shade objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    shade = Shade('Test Shade', Face3D(pts))
+    str(shade)  # test the string representation
+
+    assert shade.name == 'TestShade'
+    assert shade.name_original == 'Test Shade'
+    assert isinstance(shade.geometry, Face3D)
+    assert len(shade.vertices) == 4
+    assert shade.upper_left_vertices[0] == Point3D(1, 0, 3)
+    assert shade.normal == Vector3D(0, 1, 0)
+    assert shade.center == Point3D(0.5, 0, 1.5)
+    assert shade.area == 3
+    assert shade.perimeter == 8
+    assert not shade.has_parent
+
+
+def test_shade_from_vertices():
+    """Test the initialization of shade objects from vertices."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    shade = Shade.from_vertices('Test Shade', pts)
+
+    assert shade.name == 'TestShade'
+    assert shade.name_original == 'Test Shade'
+    assert isinstance(shade.geometry, Face3D)
+    assert len(shade.vertices) == 4
+    assert shade.upper_left_vertices[0] == Point3D(1, 0, 3)
+    assert shade.normal == Vector3D(0, 1, 0)
+    assert shade.center == Point3D(0.5, 0, 1.5)
+    assert shade.area == 3
+    assert shade.perimeter == 8
+    assert not shade.has_parent
+
+
+def test_shade_duplicate():
+    """Test the duplication of shade objects."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    shd_1 = Shade('Test Shade', Face3D(pts))
+    shd_2 = shd_1.duplicate()
+
+    assert shd_1 is not shd_2
+    for i, pt in enumerate(shd_1.vertices):
+        assert pt == shd_2.vertices[i]
+    assert shd_1.name == shd_2.name
+
+    shd_2.move(Vector3D(0, 1, 0))
+    for i, pt in enumerate(shd_1.vertices):
+        assert pt != shd_2.vertices[i]
+
+
+def test_move():
+    """Test the shade move method."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(2, 0, 0), Point3D(2, 2, 0), Point3D(0, 2, 0))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 0))
+    shade = Shade('Rectangle Shade', Face3D(pts_1, plane_1))
+
+    vec_1 = Vector3D(2, 2, 2)
+    new_shd = shade.duplicate()
+    new_shd.move(vec_1)
+    assert new_shd.geometry[0] == Point3D(2, 2, 2)
+    assert new_shd.geometry[1] == Point3D(4, 2, 2)
+    assert new_shd.geometry[2] == Point3D(4, 4, 2)
+    assert new_shd.geometry[3] == Point3D(2, 4, 2)
+    assert new_shd.normal == shade.normal
+    assert shade.area == new_shd.area
+    assert shade.perimeter == new_shd.perimeter
+
+
+def test_scale():
+    """Test the shade scale method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    shade = Shade('Rectangle Shade', Face3D(pts, plane))
+
+    new_shd = shade.duplicate()
+    new_shd.scale(2)
+    assert new_shd.geometry[0] == Point3D(2, 2, 4)
+    assert new_shd.geometry[1] == Point3D(4, 2, 4)
+    assert new_shd.geometry[2] == Point3D(4, 4, 4)
+    assert new_shd.geometry[3] == Point3D(2, 4, 4)
+    assert new_shd.area == shade.area * 2 ** 2
+    assert new_shd.perimeter == shade.perimeter * 2
+    assert new_shd.normal == shade.normal
+
+
+def test_rotate():
+    """Test the shade rotate method."""
+    pts = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    shade = Shade('Rectangle Shade', Face3D(pts, plane))
+    origin = Point3D(0, 0, 0)
+    axis = Vector3D(1, 0, 0)
+
+    test_1 = shade.duplicate()
+    test_1.rotate(axis, 180, origin)
+    assert test_1.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(-2, rel=1e-3)
+    assert shade.area == test_1.area
+    assert len(shade.vertices) == len(test_1.vertices)
+
+    test_2 = shade.duplicate()
+    test_2.rotate(axis, 90, origin)
+    assert test_2.geometry[0].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[0].z == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(-2, rel=1e-3)
+    assert test_2.geometry[2].z == pytest.approx(2, rel=1e-3)
+    assert shade.area == test_2.area
+    assert len(shade.vertices) == len(test_2.vertices)
+
+
+def test_rotate_xy():
+    """Test the Shade rotate_xy method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    shade = Shade('Rectangle Shade', Face3D(pts, plane))
+    origin_1 = Point3D(1, 1, 0)
+
+    test_1 = shade.duplicate()
+    test_1.rotate_xy(180, origin_1)
+    assert test_1.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].y == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = shade.duplicate()
+    test_2.rotate_xy(90, origin_1)
+    assert test_2.geometry[0].x == pytest.approx(1, rel=1e-3)
+    assert test_2.geometry[0].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[0].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[2].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[2].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[2].z == pytest.approx(2, rel=1e-3)
+
+
+def test_reflect():
+    """Test the Shade reflect method."""
+    pts = (Point3D(1, 1, 2), Point3D(2, 1, 2), Point3D(2, 2, 2), Point3D(1, 2, 2))
+    plane = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    shade = Shade('Rectangle Shade', Face3D(pts, plane))
+
+    origin_1 = Point3D(1, 0, 2)
+    origin_2 = Point3D(0, 0, 2)
+    normal_1 = Vector3D(1, 0, 0)
+    normal_2 = Vector3D(-1, -1, 0).normalize()
+    plane_1 = Plane(normal_1, origin_1)
+    plane_2 = Plane(normal_2, origin_2)
+    plane_3 = Plane(normal_2, origin_1)
+
+    test_1 = shade.duplicate()
+    test_1.reflect(plane_1)
+    assert test_1.geometry[-1].x == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(0, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_1 = shade.duplicate()
+    test_1.reflect(plane_2)
+    assert test_1.geometry[-1].x == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].y == pytest.approx(-1, rel=1e-3)
+    assert test_1.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_1.geometry[1].x == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].y == pytest.approx(-2, rel=1e-3)
+    assert test_1.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+    test_2 = shade.duplicate()
+    test_2.reflect(plane_3)
+    assert test_2.geometry[-1].x == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].y == pytest.approx(0, rel=1e-3)
+    assert test_2.geometry[-1].z == pytest.approx(2, rel=1e-3)
+    assert test_2.geometry[1].x == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].y == pytest.approx(-1, rel=1e-3)
+    assert test_2.geometry[1].z == pytest.approx(2, rel=1e-3)
+
+
+def test_check_planar():
+    """Test the check_planar method."""
+    pts_1 = (Point3D(0, 0, 2), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    pts_3 = (Point3D(0, 0, 2.0001), Point3D(2, 0, 2), Point3D(2, 2, 2), Point3D(0, 2, 2))
+    plane_1 = Plane(Vector3D(0, 0, 1), Point3D(0, 0, 2))
+    shade_1 = Shade('Shade 1', Face3D(pts_1, plane_1))
+    shade_2 = Shade('Shade 2', Face3D(pts_2, plane_1))
+    shade_3 = Shade('Shade 3', Face3D(pts_3, plane_1))
+
+    assert shade_1.check_planar(0.001) is True
+    assert shade_2.check_planar(0.001, False) is False
+    with pytest.raises(Exception):
+        shade_2.check_planar(0.0001)
+    assert shade_3.check_planar(0.001) is True
+    assert shade_3.check_planar(0.000001, False) is False
+    with pytest.raises(Exception):
+        shade_3.check_planar(0.000001)
+
+
+def test_check_self_intersecting():
+    """Test the check_self_intersecting method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    plane_2 = Plane(Vector3D(0, 0, -1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2), Point3D(0, 2))
+    pts_2 = (Point3D(0, 0), Point3D(0, 2), Point3D(2, 0), Point3D(2, 2))
+    shade_1 = Shade('shade 1', Face3D(pts_1, plane_1))
+    shade_2 = Shade('shade 2', Face3D(pts_2, plane_1))
+    shade_3 = Shade('shade 3', Face3D(pts_1, plane_2))
+    shade_4 = Shade('shade 4', Face3D(pts_2, plane_2))
+
+    assert shade_1.check_self_intersecting(False) is True
+    assert shade_2.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert shade_2.check_self_intersecting(True)
+    assert shade_3.check_self_intersecting(False) is True
+    assert shade_4.check_self_intersecting(False) is False
+    with pytest.raises(Exception):
+        assert shade_4.check_self_intersecting(True)
+
+
+def test_check_non_zero():
+    """Test the check_non_zero method."""
+    plane_1 = Plane(Vector3D(0, 0, 1))
+    pts_1 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 2))
+    pts_2 = (Point3D(0, 0), Point3D(2, 0), Point3D(2, 0))
+    shade_1 = Shade('shade 1', Face3D(pts_1, plane_1))
+    shade_2 = Shade('shade 2', Face3D(pts_2, plane_1))
+
+    assert shade_1.check_non_zero(0.0001, False) is True
+    assert shade_2.check_non_zero(0.0001, False) is False
+    with pytest.raises(Exception):
+        assert shade_2.check_self_intersecting(0.0001, True)
+
+
+def test_to_dict():
+    """Test the shade to_dict method."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    dr = Shade.from_vertices('Rectangle Shade', vertices)
+
+    drd = dr.to_dict()
+    assert drd['type'] == 'Shade'
+    assert drd['name'] == 'RectangleShade'
+    assert drd['name_original'] == 'Rectangle Shade'
+    assert 'geometry' in drd
+    assert len(drd['geometry']['boundary']) == len(vertices)
+    assert 'properties' in drd
+    assert drd['properties']['type'] == 'ShadeProperties'
+    assert drd['parent'] is None

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -1,0 +1,158 @@
+"""test Face class."""
+from honeybee.typing import valid_string, valid_rad_string, valid_ep_string, \
+    float_in_range, int_in_range, float_positive, int_positive, \
+    tuple_with_length, list_with_length, normpath
+
+import pytest
+
+
+def test_valid_string():
+    """Test the valid_string method."""
+    correct_str = '0.5 in. Gypsum Wall'
+    incorrect_str = '0.5 in., Gypsum Wall'
+    long_str = 'This is an exceptionally long text string that should never be used ' \
+        'for the name of anything in EnergyPlus for whatever reason'
+
+    assert valid_string(correct_str) == '0.5in.GypsumWall'
+    assert valid_string(incorrect_str) == '0.5in.GypsumWall'
+    with pytest.raises(AssertionError):
+        valid_string(long_str)
+
+
+def test_valid_rad_string():
+    """Test the valid_rad_string method."""
+    correct_str = '0.5 in. Gypsum Wall'
+    incorrect_str = '0.5 in., Gypsum Wall'
+    long_str = 'This is an exceptionally long text string that should never be used ' \
+        'for the name of anything in EnergyPlus but is actually ok for Radiance'
+
+    assert valid_rad_string(correct_str) == '0.5in.GypsumWall'
+    assert valid_rad_string(incorrect_str) == '0.5in.GypsumWall'
+    valid_rad_string(long_str)
+
+
+def test_valid_ep_string():
+    """Test the valid_ep_string method."""
+    correct_str = '1/2 in. Gypsum Board'
+    incorrect_str = '1/2 in., Gypsum Board!'
+    long_str = 'This is an exceptionally long text string that should never be used ' \
+        'for the name of anything in EnergyPlus'
+
+    assert valid_ep_string(correct_str) == correct_str
+    assert valid_ep_string(incorrect_str) == correct_str
+    with pytest.raises(AssertionError):
+        valid_ep_string(long_str)
+
+
+def test_float_in_range():
+    """Test the float_in_range method."""
+    assert isinstance(float_in_range(2.0, 0, 10, 'test number'), float)
+    assert isinstance(float_in_range(2, 0, 10, 'test number'), float)
+    assert isinstance(float_in_range('2', 0, 10, 'test number'), float)
+
+    with pytest.raises(AssertionError):
+        assert isinstance(float_in_range(2, 0, 1, 'test number'), float)
+    with pytest.raises(TypeError):
+        assert isinstance(float_in_range('two', 0, 10, 'test number'), float)
+    with pytest.raises(TypeError):
+        assert isinstance(float_in_range([2], 0, 10, 'test number'), float)
+
+    try:
+        float_in_range(2, 0, 1, 'test number')
+    except AssertionError as e:
+        assert 'test number' in str(e)
+
+
+def test_int_in_range():
+    """Test the float_in_range method."""
+    assert isinstance(int_in_range(2.0, 0, 10), int)
+    assert isinstance(int_in_range(2, 0, 10), int)
+    assert isinstance(int_in_range('2', 0, 10), int)
+
+    with pytest.raises(AssertionError):
+        assert isinstance(int_in_range(2, 0, 1), float)
+    with pytest.raises(TypeError):
+        assert isinstance(int_in_range('two', 0, 10), float)
+    with pytest.raises(TypeError):
+        assert isinstance(int_in_range([2], 0, 10), float)
+
+    try:
+        int_in_range(2, 0, 1, 'test number')
+    except AssertionError as e:
+        assert 'test number' in str(e)
+
+
+def test_float_positive():
+    """Test the float_positive method."""
+    assert isinstance(float_positive(2.0), float)
+    assert isinstance(float_positive(2), float)
+    assert isinstance(float_positive('2'), float)
+
+    with pytest.raises(AssertionError):
+        assert isinstance(float_positive(-2), float)
+    with pytest.raises(TypeError):
+        assert isinstance(float_positive('two'), float)
+    with pytest.raises(TypeError):
+        assert isinstance(float_positive([2]), float)
+
+    try:
+        float_positive(-2, 'test number')
+    except AssertionError as e:
+        assert 'test number' in str(e)
+
+
+def test_int_positive():
+    """Test the int_positive method."""
+    assert isinstance(int_positive(2.0), int)
+    assert isinstance(int_positive(2), int)
+    assert isinstance(int_positive('2'), int)
+
+    with pytest.raises(AssertionError):
+        assert isinstance(int_positive(-2), float)
+    with pytest.raises(TypeError):
+        assert isinstance(int_positive('two'), float)
+    with pytest.raises(TypeError):
+        assert isinstance(int_positive([2]), float)
+
+    try:
+        int_positive(-2, 'test number')
+    except AssertionError as e:
+        assert 'test number' in str(e)
+
+
+def test_tuple_with_length():
+    """Test the tuple_with_length method."""
+    assert isinstance(tuple_with_length((1, 2, 3), 3, float, 'test tuple'), tuple)
+    assert isinstance(tuple_with_length([1, 2, 3], 3, float, 'test tuple'), tuple)
+    assert isinstance(tuple_with_length(range(3), 3, float, 'test tuple'), tuple)
+    assert isinstance(tuple_with_length((1.0, 2.0, 3.0), 3, float, 'test tuple'), tuple)
+    assert isinstance(tuple_with_length(('1', '2', '3'), 3, float, 'test tuple'), tuple)
+
+    with pytest.raises(AssertionError):
+        tuple_with_length((1, 2, 3), 4, float, 'test tuple')
+    with pytest.raises(TypeError):
+        tuple_with_length(('one', 'two', 'three'), 3, float, 'test tuple')
+
+    try:
+        tuple_with_length((1, 2, 3), 4, float, 'test tuple')
+    except AssertionError as e:
+        assert 'test tuple' in str(e)
+
+
+def test_list_with_length():
+    """Test the list_with_length method."""
+    assert isinstance(list_with_length((1, 2, 3), 3, float, 'test list'), list)
+    assert isinstance(list_with_length([1, 2, 3], 3, float, 'test list'), list)
+    assert isinstance(list_with_length(range(3), 3, float, 'test list'), list)
+    assert isinstance(list_with_length((1.0, 2.0, 3.0), 3, float, 'test list'), list)
+    assert isinstance(list_with_length(('1', '2', '3'), 3, float, 'test list'), list)
+
+    with pytest.raises(AssertionError):
+        list_with_length((1, 2, 3), 4, float, 'test list')
+    with pytest.raises(TypeError):
+        list_with_length(('one', 'two', 'three'), 3, float, 'test list')
+
+    try:
+        list_with_length((1, 2, 3), 4, float, 'test list')
+    except AssertionError as e:
+        assert 'test list' in str(e)


### PR DESCRIPTION
This PR is fleshing out the key objects that make up honeybee-core and lays down a lot of rules for how they interact with one another. I am only submitting this as a draft PR since I don't think it's worthwhile to write all of the tests until @mostaphaRoudsari has gotten the chance to review it (I am anticipating some feedback that will result in changes).

Over the course of fleshing everything out, I came to a couple of realizations/limitations of using `weakref.proxy` that have some important implications for the core library (assuming we want to continue using it):
1) Because all of the variables that exist within a given method on a class are garbage collected after the method is run (except for the returned variables), we will not be able to implement methods that automatically generate AND add sub-faces to a honeybee face.  We can still have methods to generate sub-faces from a base face and we can have another method that adds sub-faces to the face but these two methods have to be separate from one another such that the generated sub-faces get returned from the method and are not garbage collected.  So, if you want to add apertures to a face based on a ratio, you need to call two separate methods as you see below.
It is not the most intuitive design to make 2 calls here and I had forgotten a few times in the tests that I wrote to add the apertures to the face after generating them.  However, I think that I can personally live with making two calls instead of one for this situation if you think the benefit of weakref outweighs the lack of intuitiveness.
```
apertures = face.apertures_by_ratio(0.4)
face.add_apertures(apertures)
```
2) One thing that I would not be able to live with, however, is the use of weakref for the relationship between faces and zones.  This is partly because of the fact noted above, in that it prevents us from having classmethods on the zone that allow us to create a zone without having honeybee faces to begin with (something that I think we agree is critical for if you want to make a zone from a ladybug_geometry Polyface3D or create a zone from a box).  However, it's also because the zone relies on the faces to define its geometry in a way that none of the other objects in the library rely on one another.  So, if we want to have properties on the zone like `volume` or we want to have the zone automatically flip face geometries so that they are all pointing outward from the zone, we really can't use weakrefs because the zone really can't exist in a geometric sense without the faces.

Among a few other things to note that I would really like your feedback on @mostaphaRoudsari :
1) You will see that methods to generate shade geometries from apertures are implemented on the Face level of the schema and not the Aperture (where I initially tried to put them and where we would probably agree that they make the most sense).  The reason for this is that, because shades are on the Face level and not the sub-face level, you get a circular import when you try to `import Face` in `aperture.py`.  I wasn't sure if you preferred to deal with this via importing Face within the shade method or doing something in `__init__.py` like we do with datacollections and datatype so I left it as is for now for you to comment.
2) The implementation of `apreturetypes` is in line with how we are implementing `ConstructionSets` in `honeybee-energy` and I wanted to know if you feel that this is ok.  We could also try to deal with it in the same way that we deal with adiabatic boundary conditions in that it exists in `honeybee_energy` and extends base window types but there would probably be no base window types if this was the case. There was no need for a `doortypes`, since all of the different types of doors in the ConstructionSet are defined by their boundary condition or relationship to parent.
3) I just wanted to note that all of the capabilities of the [honeybee room](https://github.com/ladybug-tools/honeybee/blob/master/honeybee/room.py) have been implemented on the Zone. When you initialize the Zone `from_box`, you get something that is virtually identical to the room except that you have multiple options for adding apertures (including `apertures_by_ratio`).  When you generate a mesh grid from the zone, you will get the grid oriented along the width/depth dimensions of the box.  The one thing that you will need to add to give it all of the room capabilities is the method that auto-generates the Radiance view, which I imagine you will extend the zone with.
4) One thing that I initially tried to implement in the core was enforcing checks that apertures were valid sub-faces of their parent face (in the same plane and completely bounded by it) but I realized this is very difficult if we want to make "the pizza" that can accept geometry from all different models of different tolerances.  A similar situation happened when I tried enforce closed zone geometry in the `__init__` of the Zone in that it virtually kills the ability to import any model that doesn't have its tolerance known or is intentionally not closed.  All of the tools exist within `ladybug_geometry' to perform these geometry checks and, for the case of the zone, I implemented such checking abilities on all of the classmethods.  However, it seems that we might ultimately need to run these checks on the plugin end rather than make them a universally-enforced part of the core.  Let me know if you can live with this.
5) Generally, there are a lot of rules that I implemented across the setters in order to ensure that we don't get things like apertures being assigned to shade geometries or air walls.  This should generally mean that people will get an error when the make something incorrect rather than waiting for the engine to give them an error, which is what we want.  However, I was wondering if you thought some of the setters might be too bogged down with checks that we should consider removing them.

resolves #8 
resolves #7 
