### PR TITLE
fix(properties): Ensuring extension properties are correctly duplicated

### DIFF
--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -8,6 +8,7 @@ on their own but should have a host object.
 
 class _Properties(object):
     """Base class for all Properties classes."""
+    _do_not_duplicate = ('host', 'ToString', 'to_dict', 'duplicate_extension_attr')
 
     def __init__(self, host):
         """Initialize properties.
@@ -31,12 +32,13 @@ class _Properties(object):
                 the duplicate object will be derived.
         """
         attr = [atr for atr in dir(self)
-                if not atr.startswith('_') and atr != 'host']
+                if not atr.startswith('_') and atr not in
+                self._do_not_duplicate]
 
         for atr in attr:
             var = getattr(original_properties, atr)
             try:
-                setattr(self, atr, var.duplicate(self.host))
+                setattr(self, '_' + atr, var.duplicate(self.host))
             except AttributeError:
                 pass  # it is not an attribute that can be duplicated
 


### PR DESCRIPTION
Very minor tweak to the duplicate_extension_attr method that all honeybee-core properties objects share.  The tweak ensures that the properties added by extensions are correctly duplicated.  It also includes a slight performance improvement by catching properties that should not be duplicated before they go into a try/except loop to duplicate them.