### PR TITLE
ci(project manager): add initial config

### DIFF
--- a/.github/project-manager.yml
+++ b/.github/project-manager.yml
@@ -1,0 +1,137 @@
+issue:
+  opened:
+    addLabels:
+      - honeybee
+      - core
+      - triage
+  closed:
+    addLabels:
+      - done
+
+pull_request:
+  opened:
+    addLabels:
+      - honeybee
+      - core
+  closed:
+    addLabels:
+      - done
+
+projects:  
+  - name: Global Kanban
+    type: org
+    issue_type: issue
+    columns:
+      - name: triage
+        labels:
+          - triage
+        actions:
+          removeLabels:
+            - backlog
+            - todo
+            - in progress
+            - done 
+      - name: backlog
+        labels:
+          - backlog
+        actions:
+          removeLabels:
+            - triage
+            - todo
+            - in progress
+            - done 
+      - name: todo
+        labels:
+          - todo
+        actions:
+          removeLabels:
+            - triage
+            - backlog
+            - in progress
+            - done 
+      - name: in progress
+        labels:
+          - in progress
+        actions:
+          removeLabels:
+            - triage
+            - todo
+            - backlog
+            - done
+      - name: done
+        labels:
+          - done 
+        actions:
+          removeLabels:
+            - triage
+            - backlog
+            - todo
+            - in progress
+
+  - name: Repo Kanban
+    type: repo
+    issue_type: issue
+    columns:
+      - name: triage
+        labels:
+          - triage
+        actions:
+          removeLabels:
+            - backlog
+            - todo
+            - in progress
+            - done 
+      - name: backlog
+        labels:
+          - backlog
+        actions:
+          removeLabels:
+            - triage
+            - todo
+            - in progress
+            - done 
+      - name: todo
+        labels:
+          - todo
+        actions:
+          removeLabels:
+            - triage
+            - backlog
+            - in progress
+            - done 
+      - name: in progress
+        labels:
+          - in progress
+        actions:
+          removeLabels:
+            - triage
+            - todo
+            - backlog
+            - done
+      - name: done
+        labels:
+          - done 
+        actions:
+          removeLabels:
+            - triage
+            - backlog
+            - todo
+            - in progress
+
+
+labels:
+- name: honeybee
+  color: "#FFFB00"
+- name: core
+  color: "#0075CA"
+
+- name: in progress
+  color: "#EDEDED"
+- name: triage
+  color: "#EDEDED"
+- name: todo
+  color: "#EDEDED"
+- name: backlog
+  color: "#EDEDED"
+- name: done
+  color: "#EDEDED"


### PR DESCRIPTION
This config adds all issues (non pull requests) to a repo and org level kanban boards. Issues will
be moved across boards according to the `labels` value of each column. Finally, new issues and pull requests will have labels automatically added to them as per the config. Some normalisation is also set up to ensure coordinated color between labels.

In order for this to take effect, @mostaphaRoudsari or @chriswmackey will have to authorise the `project-manager` github app to the ladybug-tools org. I have created this app and the source code can be found [here](https://github.com/antoinedao/project-manager).