### PR TITLE
feat(room): Add property for Room multiplier

### DIFF
--- a/honeybee/_base.py
+++ b/honeybee/_base.py
@@ -33,7 +33,7 @@ class _Base(object):
 
     @property
     def display_name(self):
-        """Original input name by user.
+        """Get the original input name by user.
 
         If there are no illegal characters in name then name and display_name will
         be the same. Legal characters are ., A-Z, a-z, 0-9, _ and -.
@@ -44,7 +44,7 @@ class _Base(object):
 
     @property
     def properties(self):
-        """Object properties, including Radiance, Energy and other properties."""
+        """Get object properties, including Radiance, Energy and other properties."""
         return self._properties
 
     def duplicate(self):

--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -8,11 +8,12 @@ class _BaseWithShade(_Base):
     """A base class for all objects that can have Shades nested on them.
 
     Properties:
-        name
-        display_name
-        geometry
-        outdoor_shades
-        indoor_shades
+        * name
+        * display_name
+        * geometry
+        * outdoor_shades
+        * indoor_shades
+        * shades
     """
     __slots__ = ('_outdoor_shades', '_indoor_shades')
 
@@ -28,17 +29,17 @@ class _BaseWithShade(_Base):
 
     @property
     def outdoor_shades(self):
-        """Array of all outdoor shades assigned to this object."""
+        """Get an array of all outdoor shades assigned to this object."""
         return tuple(self._outdoor_shades)
 
     @property
     def indoor_shades(self):
-        """Array of all indoor shades assigned to this object."""
+        """Get an array of all indoor shades assigned to this object."""
         return tuple(self._indoor_shades)
 
     @property
     def shades(self):
-        """Array of all shades (both indoor and outdoor) assigned to this object."""
+        """Get an array of all shades (indoor + outdoor) assigned to this object."""
         return self._outdoor_shades + self._indoor_shades
 
     def remove_shades(self):

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -16,22 +16,22 @@ class Aperture(_BaseWithShade):
     """A single planar Aperture in a Face.
 
     Properties:
-        name
-        display_name
-        boundary_condition
-        is_operable
-        indoor_shades
-        outdoor_shades
-        parent
-        has_parent
-        geometry
-        vertices
-        upper_left_vertices
-        triangulated_mesh3d
-        normal
-        center
-        area
-        perimeter
+        * name
+        * display_name
+        * boundary_condition
+        * is_operable
+        * indoor_shades
+        * outdoor_shades
+        * parent
+        * has_parent
+        * geometry
+        * vertices
+        * upper_left_vertices
+        * triangulated_mesh3d
+        * normal
+        * center
+        * area
+        * perimeter
     """
     __slots__ = ('_geometry', '_parent', '_boundary_condition', '_is_operable')
 
@@ -108,7 +108,7 @@ class Aperture(_BaseWithShade):
 
     @property
     def boundary_condition(self):
-        """Boundary condition of this aperture."""
+        """Get or set the boundary condition of this aperture."""
         return self._boundary_condition
 
     @boundary_condition.setter
@@ -124,7 +124,8 @@ class Aperture(_BaseWithShade):
 
     @property
     def is_operable(self):
-        """Boolean to note whether the Aperture can be opened for ventilation."""
+        """Get or set a boolean for whether the Aperture can be opened for ventilation.
+        """
         return self._is_operable
 
     @is_operable.setter
@@ -137,27 +138,27 @@ class Aperture(_BaseWithShade):
 
     @property
     def parent(self):
-        """Parent Face if assigned. None if not assigned."""
+        """Get the parent Face if assigned. None if not assigned."""
         return self._parent
 
     @property
     def has_parent(self):
-        """Boolean noting whether this Aperture has a parent Face."""
+        """Get a boolean noting whether this Aperture has a parent Face."""
         return self._parent is not None
 
     @property
     def geometry(self):
-        """A ladybug_geometry Face3D object representing the aperture."""
+        """Get a ladybug_geometry Face3D object representing the aperture."""
         return self._geometry
 
     @property
     def vertices(self):
-        """List of vertices for the aperture (in counter-clockwise order)."""
+        """Get a list of vertices for the aperture (in counter-clockwise order)."""
         return self._geometry.vertices
 
     @property
     def upper_left_vertices(self):
-        """List of vertices starting from the upper-left corner.
+        """Get a list of vertices starting from the upper-left corner.
 
         This property should be used when exporting to EnergyPlus / OpenStudio.
         """
@@ -165,7 +166,7 @@ class Aperture(_BaseWithShade):
 
     @property
     def triangulated_mesh3d(self):
-        """A ladybug_geometry Mesh3D of the aperture geometry composed of triangles.
+        """Get a ladybug_geometry Mesh3D of the aperture geometry composed of triangles.
 
         In EnergyPlus / OpenStudio workflows, this property is used to subdivide
         the aperture when it has more than 4 vertices. This is necessary since
@@ -175,13 +176,13 @@ class Aperture(_BaseWithShade):
 
     @property
     def normal(self):
-        """A ladybug_geometry Vector3D for the direction the aperture is pointing.
+        """Get a ladybug_geometry Vector3D for the direction the aperture is pointing.
         """
         return self._geometry.normal
 
     @property
     def center(self):
-        """A ladybug_geometry Point3D for the center of the aperture.
+        """Get a ladybug_geometry Point3D for the center of the aperture.
 
         Note that this is the center of the bounding rectangle around this geometry
         and not the area centroid.
@@ -190,12 +191,12 @@ class Aperture(_BaseWithShade):
 
     @property
     def area(self):
-        """The area of the aperture."""
+        """Get the area of the aperture."""
         return self._geometry.area
 
     @property
     def perimeter(self):
-        """The perimeter of the aperture."""
+        """Get the perimeter of the aperture."""
         return self._geometry.perimeter
 
     def set_adjacency(self, other_aperture):

--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -13,26 +13,26 @@ class _BoundaryCondition(object):
 
     @property
     def name(self):
-        """Name of the boundary condition (ie. 'Outdoors', 'Ground')."""
+        """Get the name of the boundary condition (ie. 'Outdoors', 'Ground')."""
         return self.__class__.__name__
 
     @property
     def view_factor(self):
-        """The view factor to the ground."""
+        """Get the view factor to the ground."""
         return 'autocalculate'
 
     @property
     def sun_exposure_idf(self):
-        """Text string for sun exposure, which is write-able into an IDF."""
+        """Get a text string for sun exposure, which is write-able into an IDF."""
         return 'NoSun'
 
     @property
     def wind_exposure_idf(self):
-        """Text string for wind exposure, which is write-able into an IDF."""
+        """ Get a text string for wind exposure, which is write-able into an IDF."""
         return 'NoWind'
 
     def to_dict(self):
-        """Get boundary condition as a dictionary."""
+        """Get the boundary condition as a dictionary."""
         return {'type': self.name}
 
     def ToString(self):
@@ -90,31 +90,31 @@ class Outdoors(_BoundaryCondition):
 
     @property
     def sun_exposure(self):
-        """A boolean noting whether the boundary is exposed to sun."""
+        """Get a boolean noting whether the boundary is exposed to sun."""
         return self._sun_exposure
 
     @property
     def wind_exposure(self):
-        """A boolean noting whether the boundary is exposed to wind."""
+        """Get a boolean noting whether the boundary is exposed to wind."""
         return self._wind_exposure
 
     @property
     def view_factor(self):
-        """The view factor to the ground as a number or 'autocalculate'."""
+        """Get the view factor to the ground as a number or 'autocalculate'."""
         return self._view_factor
 
     @property
     def sun_exposure_idf(self):
-        """Text string for sun exposure, which is write-able into an IDF."""
+        """Get a text string for sun exposure, which is write-able into an IDF."""
         return 'NoSun' if not self.sun_exposure else 'SunExposed'
 
     @property
     def wind_exposure_idf(self):
-        """Text string for wind exposure, which is write-able into an IDF."""
+        """Get a text string for wind exposure, which is write-able into an IDF."""
         return 'NoWind' if not self.wind_exposure else 'WindExposed'
 
     def to_dict(self, full=False):
-        """Get boundary condition as a dictionary.
+        """Get the boundary condition as a dictionary.
 
         Args:
             full: Set to True to get the full dictionary which includes energy
@@ -198,7 +198,7 @@ class Surface(_BoundaryCondition):
 
     @property
     def boundary_condition_objects(self):
-        """A tuple of up to 3 object names that are adjacent to this one.
+        """Get a tuple of up to 3 object names that are adjacent to this one.
 
         The first object is always the one that is immediately adjacet and is of
         the same object type (Face, Aperture, Door).
@@ -212,11 +212,11 @@ class Surface(_BoundaryCondition):
 
     @property
     def boundary_condition_object(self):
-        """The name of the object adjacent to this one."""
+        """Get the name of the object adjacent to this one."""
         return self._boundary_condition_objects[0]
 
     def to_dict(self):
-        """Get boundary condition as a dictionary.
+        """Get the boundary condition as a dictionary.
 
         Args:
             full: Set to True to get the full dictionary which includes energy

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -15,20 +15,20 @@ class Door(_Base):
     """A single planar Door in a Face.
 
     Properties:
-        name
-        display_name
-        boundary_condition
-        is_glass
-        parent
-        has_parent
-        geometry
-        vertices
-        upper_left_vertices
-        triangulated_mesh3d
-        normal
-        center
-        area
-        perimeter
+        * name
+        * display_name
+        * boundary_condition
+        * is_glass
+        * parent
+        * has_parent
+        * geometry
+        * vertices
+        * upper_left_vertices
+        * triangulated_mesh3d
+        * normal
+        * center
+        * area
+        * perimeter
     """
     __slots__ = ('_geometry', '_parent', '_boundary_condition', '_is_glass')
 
@@ -104,7 +104,7 @@ class Door(_Base):
 
     @property
     def boundary_condition(self):
-        """Boundary condition of this door."""
+        """Get or set the boundary condition of this door."""
         return self._boundary_condition
 
     @boundary_condition.setter
@@ -120,7 +120,7 @@ class Door(_Base):
 
     @property
     def is_glass(self):
-        """Boolean to note whether this object is a glass door."""
+        """Get or set a boolean to note whether this object is a glass door."""
         return self._is_glass
 
     @is_glass.setter
@@ -133,27 +133,27 @@ class Door(_Base):
 
     @property
     def parent(self):
-        """Parent Face if assigned. None if not assigned."""
+        """Get the parent Face if assigned. None if not assigned."""
         return self._parent
 
     @property
     def has_parent(self):
-        """Boolean noting whether this Door has a parent Face."""
+        """Get a boolean noting whether this Door has a parent Face."""
         return self._parent is not None
 
     @property
     def geometry(self):
-        """A ladybug_geometry Face3D object representing the door."""
+        """Get a ladybug_geometry Face3D object representing the door."""
         return self._geometry
 
     @property
     def vertices(self):
-        """List of vertices for the door (in counter-clockwise order)."""
+        """Get a list of vertices for the door (in counter-clockwise order)."""
         return self._geometry.vertices
 
     @property
     def upper_left_vertices(self):
-        """List of vertices starting from the upper-left corner.
+        """Get a list of vertices starting from the upper-left corner.
 
         This property should be used when exporting to EnergyPlus / OpenStudio.
         """
@@ -161,7 +161,7 @@ class Door(_Base):
 
     @property
     def triangulated_mesh3d(self):
-        """A ladybug_geometry Mesh3D of the door geometry composed of triangles.
+        """Get a ladybug_geometry Mesh3D of the door geometry composed of triangles.
 
         In EnergyPlus / OpenStudio workflows, this property is used to subdivide
         the door when it has more than 4 vertices. This is necessary since
@@ -171,13 +171,13 @@ class Door(_Base):
 
     @property
     def normal(self):
-        """A ladybug_geometry Vector3D for the direction the door is pointing.
+        """Get a ladybug_geometry Vector3D for the direction the door is pointing.
         """
         return self._geometry.normal
 
     @property
     def center(self):
-        """A ladybug_geometry Point3D for the center of the door.
+        """Get a ladybug_geometry Point3D for the center of the door.
 
         Note that this is the center of the bounding rectangle around this geometry
         and not the area centroid.
@@ -186,12 +186,12 @@ class Door(_Base):
 
     @property
     def area(self):
-        """The area of the door."""
+        """Get the area of the door."""
         return self._geometry.area
 
     @property
     def perimeter(self):
-        """The perimeter of the door."""
+        """Get the perimeter of the door."""
         return self._geometry.perimeter
 
     def set_adjacency(self, other_door):
@@ -345,7 +345,8 @@ class Door(_Base):
             base['geometry'] = self._geometry.to_dict(False)
 
         base['is_glass'] = self.is_glass
-        if isinstance(self.boundary_condition, Outdoors) and 'energy' in base['properties']:
+        if isinstance(self.boundary_condition, Outdoors) and \
+                'energy' in base['properties']:
             base['boundary_condition'] = self.boundary_condition.to_dict(full=True)
         else:
             base['boundary_condition'] = self.boundary_condition.to_dict()

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -23,25 +23,25 @@ class Face(_BaseWithShade):
     """A single planar face.
 
     Properties:
-        name
-        display_name
-        type
-        boundary_condition
-        apertures
-        doors
-        indoor_shades
-        outdoor_shades
-        parent
-        has_parent
-        geometry
-        punched_geometry
-        vertices
-        punched_vertices
-        upper_left_vertices
-        normal
-        center
-        area
-        perimeter
+        * name
+        * display_name
+        * type
+        * boundary_condition
+        * apertures
+        * doors
+        * indoor_shades
+        * outdoor_shades
+        * parent
+        * has_parent
+        * geometry
+        * punched_geometry
+        * vertices
+        * punched_vertices
+        * upper_left_vertices
+        * normal
+        * center
+        * area
+        * perimeter
     """
     TYPES = face_types
     __slots__ = ('_geometry', '_parent', '_punched_geometry',
@@ -141,7 +141,7 @@ class Face(_BaseWithShade):
 
     @property
     def type(self):
-        """Object for Type of Face (ie. Wall, Floor, Roof)."""
+        """Get or set an object for Type of Face (ie. Wall, Floor, Roof)."""
         return self._type
 
     @type.setter
@@ -154,7 +154,8 @@ class Face(_BaseWithShade):
 
     @property
     def boundary_condition(self):
-        """Object for the Face Boundary Condition (ie. Outdoors, Ground, etc.)."""
+        """Get or set the boundary condition of the Face. (ie. Outdoors, Ground, etc.).
+        """
         return self._boundary_condition
 
     @boundary_condition.setter
@@ -168,27 +169,27 @@ class Face(_BaseWithShade):
 
     @property
     def apertures(self):
-        """List of apertures in this Face."""
+        """Get a list of apertures in this Face."""
         return tuple(self._apertures)
 
     @property
     def doors(self):
-        """List of doors in this Face."""
+        """Get a list of doors in this Face."""
         return tuple(self._doors)
 
     @property
     def parent(self):
-        """Parent Room if assigned. None if not assigned."""
+        """Get the parent Room if assigned. None if not assigned."""
         return self._parent
 
     @property
     def has_parent(self):
-        """Boolean noting whether this Face has a parent Room."""
+        """Get a boolean noting whether this Face has a parent Room."""
         return self._parent is not None
 
     @property
     def geometry(self):
-        """A ladybug_geometry Face3D object representing the Face.
+        """Get a ladybug_geometry Face3D object representing the Face.
 
         Note that this Face3D only represents the parent face and does not have any
         holes cut in it for apertures or doors.
@@ -197,7 +198,7 @@ class Face(_BaseWithShade):
 
     @property
     def punched_geometry(self):
-        """A ladybug_geometry Face3D object with holes cut in it for apertures and doors.
+        """Get a ladybug_geometry Face3D object with holes cut in it for apertures and doors.
         """
         if self._punched_geometry is None:
             _sub_faces = tuple(sub_f.geometry for sub_f in self._apertures + self._doors)
@@ -210,7 +211,7 @@ class Face(_BaseWithShade):
 
     @property
     def vertices(self):
-        """List of vertices for the face (in counter-clockwise order).
+        """Get a list of vertices for the face (in counter-clockwise order).
 
         Note that these vertices only represent the outer boundary of the face
         and do not account for holes cut in the face by apertures or doors.
@@ -219,7 +220,7 @@ class Face(_BaseWithShade):
 
     @property
     def punched_vertices(self):
-        """List of vertices with holes cut in it for apertures and doors.
+        """Get a list of vertices with holes cut in it for apertures and doors.
 
         Note that some vertices will be repeated since the vertices effectively
         trace out a single boundary around the whole shape, winding inward to cut
@@ -229,7 +230,7 @@ class Face(_BaseWithShade):
 
     @property
     def upper_left_vertices(self):
-        """List of vertices starting from the upper-left corner.
+        """Get a list of vertices starting from the upper-left corner.
 
         This property obeys the same rules as the vertices property but always starts
         from the upper-left-most vertex.  This property should be used when exporting to
@@ -239,13 +240,13 @@ class Face(_BaseWithShade):
 
     @property
     def normal(self):
-        """A ladybug_geometry Vector3D for the direction in which the face is pointing.
+        """Get a ladybug_geometry Vector3D for the direction in which the face is pointing.
         """
         return self._geometry.normal
 
     @property
     def center(self):
-        """A ladybug_geometry Point3D for the center of the face.
+        """Get a ladybug_geometry Point3D for the center of the face.
 
         Note that this is the center of the bounding rectangle around this geometry
         and not the area centroid.
@@ -254,16 +255,17 @@ class Face(_BaseWithShade):
 
     @property
     def area(self):
-        """The area of the face."""
+        """Get the area of the face."""
         return self._geometry.area
 
     @property
     def perimeter(self):
-        """The perimeter of the face. This includes the length of holes in the face."""
+        """Get the perimeter of the face. This includes the length of holes in the face.
+        """
         return self._geometry.perimeter
 
     def horizontal_orientation(self, north_vector=Vector2D(0, 1)):
-        """A number between 0 and 360 for the orientation of the face in degrees.
+        """Get a number between 0 and 360 for the orientation of the face in degrees.
 
         0 = North, 90 = East, 180 = South, 270 = West
 
@@ -275,7 +277,7 @@ class Face(_BaseWithShade):
             north_vector.angle_clockwise(Vector2D(self.normal.x, self.normal.y)))
 
     def cardinal_direction(self, north_vector=Vector2D(0, 1)):
-        """Text description for the cardinal direction that the face is pointing.
+        """Get text description for the cardinal direction that the face is pointing.
 
         Will be one of the following: ('North', 'East', 'South', 'West')
 

--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -22,19 +22,19 @@ class Model(_Base):
     """A collection of Rooms, Faces, Shades, Apertures, and Doors representing a model.
 
     Properties:
-        name
-        display_name
-        north_angle
-        north_vector
-        rooms
-        faces
-        shades
-        apertures
-        doors
-        orphaned_faces
-        orphaned_shades
-        orphaned_apertures
-        orphaned_doors
+        * name
+        * display_name
+        * north_angle
+        * north_vector
+        * rooms
+        * faces
+        * shades
+        * apertures
+        * doors
+        * orphaned_faces
+        * orphaned_shades
+        * orphaned_apertures
+        * orphaned_doors
     """
     __slots__ = ('_rooms', '_orphaned_faces', '_orphaned_shades', '_orphaned_apertures',
                  '_orphaned_doors', '_north_angle', '_north_vector')
@@ -186,18 +186,18 @@ class Model(_Base):
 
     @property
     def rooms(self):
-        """A list of all Room objects in the model."""
+        """Get a list of all Room objects in the model."""
         return tuple(self._rooms)
 
     @property
     def faces(self):
-        """A list of all Face objects in the model."""
+        """Get a list of all Face objects in the model."""
         child_faces = [face for room in self._rooms for face in room._faces]
         return child_faces + self._orphaned_faces
 
     @property
     def shades(self):
-        """A list of all Shade objects in the model."""
+        """Get a list of all Shade objects in the model."""
         child_shades = []
         for room in self._rooms:
             child_shades.extend(room.shades)
@@ -215,7 +215,7 @@ class Model(_Base):
 
     @property
     def apertures(self):
-        """A list of all Aperture objects in the model."""
+        """Get a list of all Aperture objects in the model."""
         child_apertures = []
         for room in self._rooms:
             for face in room._faces:
@@ -226,7 +226,7 @@ class Model(_Base):
 
     @property
     def doors(self):
-        """A list of all Door objects in the model."""
+        """Get a list of all Door objects in the model."""
         child_doors = []
         for room in self._rooms:
             for face in room._faces:
@@ -237,22 +237,22 @@ class Model(_Base):
 
     @property
     def orphaned_faces(self):
-        """A list of all Face objects without parent Rooms in the model."""
+        """Get a list of all Face objects without parent Rooms in the model."""
         return tuple(self._orphaned_faces)
 
     @property
     def orphaned_shades(self):
-        """A list of all Shade objects without parent Rooms in the model."""
+        """Get a list of all Shade objects without parent Rooms in the model."""
         return tuple(self._orphaned_shades)
 
     @property
     def orphaned_apertures(self):
-        """A list of all Aperture objects without parent Faces in the model."""
+        """Get a list of all Aperture objects without parent Faces in the model."""
         return tuple(self._orphaned_apertures)
 
     @property
     def orphaned_doors(self):
-        """A list of all Door objects without parent Faces in the model."""
+        """Get a list of all Door objects without parent Faces in the model."""
         return tuple(self._orphaned_doors)
 
     def add_model(self, other_model):

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -14,17 +14,17 @@ class Shade(_Base):
     """A single planar shade.
 
     Properties:
-        name
-        display_name
-        parent
-        has_parent
-        geometry
-        vertices
-        upper_left_vertices
-        normal
-        center
-        area
-        perimeter
+        * name
+        * display_name
+        * parent
+        * has_parent
+        * geometry
+        * vertices
+        * upper_left_vertices
+        * normal
+        * center
+        * area
+        * perimeter
     """
     __slots__ = ('_geometry', '_parent')
 
@@ -82,27 +82,27 @@ class Shade(_Base):
 
     @property
     def parent(self):
-        """Parent Room if assigned. None if not assigned."""
+        """Get the parent Room if assigned. None if not assigned."""
         return self._parent
 
     @property
     def has_parent(self):
-        """Boolean noting whether this Shade has a parent Room."""
+        """Get a boolean noting whether this Shade has a parent Room."""
         return self._parent is not None
 
     @property
     def geometry(self):
-        """A ladybug_geometry Face3D object representing the Shade."""
+        """Get a ladybug_geometry Face3D object representing the Shade."""
         return self._geometry
 
     @property
     def vertices(self):
-        """List of vertices for the shade (in counter-clockwise order)."""
+        """Get a list of vertices for the shade (in counter-clockwise order)."""
         return self._geometry.vertices
 
     @property
     def upper_left_vertices(self):
-        """List of vertices starting from the upper-left corner.
+        """Get a list of vertices starting from the upper-left corner.
 
         This property should be used when exporting to EnergyPlus / OpenStudio.
         """
@@ -110,13 +110,13 @@ class Shade(_Base):
 
     @property
     def normal(self):
-        """A ladybug_geometry Vector3D for the direction the shade is pointing.
+        """Get a ladybug_geometry Vector3D for the direction the shade is pointing.
         """
         return self._geometry.normal
 
     @property
     def center(self):
-        """A ladybug_geometry Point3D for the center of the shade.
+        """Get a ladybug_geometry Point3D for the center of the shade.
 
         Note that this is the center of the bounding rectangle around this geometry
         and not the area centroid.
@@ -125,12 +125,12 @@ class Shade(_Base):
 
     @property
     def area(self):
-        """The area of the shade."""
+        """Get the area of the shade."""
         return self._geometry.area
 
     @property
     def perimeter(self):
-        """The perimeter of the shade."""
+        """Get the perimeter of the shade."""
         return self._geometry.perimeter
 
     def move(self, moving_vec):

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -339,3 +339,14 @@ def test_to_dict():
     assert ad['properties']['type'] == 'ApertureProperties'
     assert not ad['is_operable']
     assert ad['boundary_condition']['type'] == 'Outdoors'
+
+
+def test_to_from_dict():
+    """Test the to/from dict of Aperture objects."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    ap = Aperture.from_vertices('Rectangle Window', vertices)
+
+    ap_dict = ap.to_dict()
+    new_ap = Aperture.from_dict(ap_dict)
+    assert isinstance(new_ap, Aperture)
+    assert new_ap.to_dict() == ap_dict

--- a/tests/door_test.py
+++ b/tests/door_test.py
@@ -267,3 +267,14 @@ def test_to_dict():
     assert 'properties' in drd
     assert drd['properties']['type'] == 'DoorProperties'
     assert drd['boundary_condition']['type'] == 'Outdoors'
+
+
+def test_to_from_dict():
+    """Test the to/from dict of Door objects."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    dr = Door.from_vertices('Rectangle Door', vertices)
+
+    dr_dict = dr.to_dict()
+    new_dr = Door.from_dict(dr_dict)
+    assert isinstance(new_dr, Door)
+    assert new_dr.to_dict() == dr_dict

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -585,3 +585,15 @@ def test_to_dict():
     assert fd['properties']['type'] == 'FaceProperties'
     assert fd['face_type'] == 'Wall'
     assert fd['boundary_condition']['type'] == 'Ground'
+
+
+def test_to_from_dict():
+    """Test the to/from dict of Face objects."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    face = Face.from_vertices('test wall', vertices, face_types.wall,
+                              boundary_conditions.ground)
+
+    face_dict = face.to_dict()
+    new_face = Face.from_dict(face_dict)
+    assert isinstance(new_face, Face)
+    assert new_face.to_dict() == face_dict

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -33,6 +33,7 @@ def test_init():
     str(room)  # test the string representation of the room
     assert room.name == 'ZoneSHOE_BOX920980'
     assert room.display_name == 'Zone: SHOE_BOX [920980]'
+    assert room.multiplier == 1
     assert isinstance(room.geometry, Polyface3D)
     assert len(room.geometry.vertices) == 8
     assert len(room) == 6
@@ -183,6 +184,21 @@ def test_average_orientation():
 
     assert room.average_orientation() == 180
     assert room.average_orientation(Vector2D(1, 0)) == 90
+
+
+def test_room_multiplier():
+    """Test the room multiplier."""
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3)
+    south_face = room[3]
+    south_face.apertures_by_ratio(0.5, 0.01)
+
+    room.multiplier = 5
+    assert room.multiplier == 5
+    room_dup = room.duplicate()
+    assert room_dup.multiplier == 5
+    room_dict = room.to_dict()
+    assert 'multiplier' in room_dict
+    assert room_dict['multiplier'] == 5
 
 
 def test_apertures_and_shades():
@@ -479,3 +495,13 @@ def test_to_dict():
     assert 'outdoor_shades' not in rd
     assert 'properties' in rd
     assert rd['properties']['type'] == 'RoomProperties'
+
+
+def test_to_from_dict():
+    """Test the to/from dict of Room objects."""
+    room = Room.from_box('Shoe Box Zone', 5, 10, 3)
+
+    room_dict = room.to_dict()
+    new_room = Room.from_dict(room_dict)
+    assert isinstance(new_room, Room)
+    assert new_room.to_dict() == room_dict

--- a/tests/shade_test.py
+++ b/tests/shade_test.py
@@ -251,13 +251,24 @@ def test_check_non_zero():
 def test_to_dict():
     """Test the shade to_dict method."""
     vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
-    dr = Shade.from_vertices('Rectangle Shade', vertices)
+    shd = Shade.from_vertices('Rectangle Shade', vertices)
 
-    drd = dr.to_dict()
-    assert drd['type'] == 'Shade'
-    assert drd['name'] == 'RectangleShade'
-    assert drd['display_name'] == 'Rectangle Shade'
-    assert 'geometry' in drd
-    assert len(drd['geometry']['boundary']) == len(vertices)
-    assert 'properties' in drd
-    assert drd['properties']['type'] == 'ShadeProperties'
+    shdd = shd.to_dict()
+    assert shdd['type'] == 'Shade'
+    assert shdd['name'] == 'RectangleShade'
+    assert shdd['display_name'] == 'Rectangle Shade'
+    assert 'geometry' in shdd
+    assert len(shdd['geometry']['boundary']) == len(vertices)
+    assert 'properties' in shdd
+    assert shdd['properties']['type'] == 'ShadeProperties'
+
+
+def test_to_from_dict():
+    """Test the to/from dict of Shade objects."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    shd = Shade.from_vertices('Rectangle Shade', vertices)
+
+    shd_dict = shd.to_dict()
+    new_shd = Shade.from_dict(shd_dict)
+    assert isinstance(new_shd, Shade)
+    assert new_shd.to_dict() == shd_dict


### PR DESCRIPTION
I know that multipliers clearly have a use in energy simulation but, after thinking about it, they are just as helpful in computing daylight metrics over buildings and so they really should live in honeybee-core. So this commit adds them as a property on the room.

I also took the opportunity to revise several of the docstrings to make it clear which core properties are set-able or not (following a convention that I originally saw in RhinoCommon). You don't really have to review these though, @mostapharoudsari . Just looking over the Room changes and letting me know if you agree is good.