### PR TITLE
feat(writer): Break down writers for individual geometry objects

### DIFF
--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -4,7 +4,7 @@ from ._basewithshade import _BaseWithShade
 from .properties import ApertureProperties
 from .boundarycondition import boundary_conditions, Outdoors, Surface
 from .shade import Shade
-import honeybee.writer as writer
+import honeybee.writer.aperture as writer
 
 from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
 from ladybug_geometry.geometry3d.face import Face3D

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -3,7 +3,7 @@
 from ._base import _Base
 from .properties import DoorProperties
 from .boundarycondition import boundary_conditions, Outdoors, Surface
-import honeybee.writer as writer
+import honeybee.writer.door as writer
 
 from ladybug_geometry.geometry3d.pointvector import Point3D
 from ladybug_geometry.geometry3d.face import Face3D

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -9,7 +9,7 @@ from .shade import Shade
 from .aperture import Aperture
 from .door import Door
 import honeybee.boundarycondition as hbc
-import honeybee.writer as writer
+import honeybee.writer.face as writer
 
 from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
 from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D

--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -10,7 +10,7 @@ from .door import Door
 from .typing import float_in_range
 from .boundarycondition import Surface
 from .facetype import AirWall
-import honeybee.writer as writer
+import honeybee.writer.model as writer
 
 from ladybug_geometry.geometry2d.pointvector import Vector2D
 from ladybug_geometry.geometry3d.face import Face3D

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -6,7 +6,7 @@ from .face import Face
 from .facetype import get_type_from_normal, Wall, Floor
 from .boundarycondition import get_bc_from_position, Outdoors, Surface
 from .typing import float_in_range, int_in_range
-import honeybee.writer as writer
+import honeybee.writer.room as writer
 
 from ladybug_geometry.geometry2d.pointvector import Vector2D
 from ladybug_geometry.geometry3d.pointvector import Vector3D, Point3D

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -2,7 +2,7 @@
 """Honeybee Shade."""
 from ._base import _Base
 from .properties import ShadeProperties
-import honeybee.writer as writer
+import honeybee.writer.shade as writer
 
 from ladybug_geometry.geometry3d.pointvector import Point3D
 from ladybug_geometry.geometry3d.face import Face3D

--- a/honeybee/writer.py
+++ b/honeybee/writer.py
@@ -1,6 +1,0 @@
-"""Geometry Writer.
-
-Note for developers:
-
-Use this module to extend honeybee's geometry writer for new plugins.
-"""

--- a/honeybee/writer/__init__.py
+++ b/honeybee/writer/__init__.py
@@ -1,0 +1,7 @@
+"""Geometry Writers.
+
+Note to developers:
+Use this package to extend honeybee's geometry writers for new plugins.
+Functions added to the respective module of a given geometry object
+will show up under ther `to` method of the given object.
+"""

--- a/honeybee/writer/__init__.py
+++ b/honeybee/writer/__init__.py
@@ -1,7 +1,7 @@
 """Geometry Writers.
 
 Note to developers:
-Use this package to extend honeybee's geometry writers for new plugins.
+Use this package to extend honeybee's geometry writers for new extensions.
 Functions added to the respective module of a given geometry object
 will show up under ther `to` method of the given object.
 """

--- a/honeybee/writer/aperture.py
+++ b/honeybee/writer/aperture.py
@@ -1,6 +1,6 @@
 """Aperture Writer.
 
 Note to developers:
-Use this module to extend honeybee's Aperture writer for new plugins.
+Use this module to extend honeybee's Aperture writer for new extensions.
 (eg. adding `idf` to this module adds the method `Aperture.to.idf`)
 """

--- a/honeybee/writer/aperture.py
+++ b/honeybee/writer/aperture.py
@@ -1,0 +1,6 @@
+"""Aperture Writer.
+
+Note to developers:
+Use this module to extend honeybee's Aperture writer for new plugins.
+(eg. adding `idf` to this module adds the method `Aperture.to.idf`)
+"""

--- a/honeybee/writer/door.py
+++ b/honeybee/writer/door.py
@@ -1,0 +1,6 @@
+"""Door Writer.
+
+Note to developers:
+Use this module to extend honeybee's Door writer for new plugins.
+(eg. adding `idf` to this module adds the method `Door.to.idf`)
+"""

--- a/honeybee/writer/door.py
+++ b/honeybee/writer/door.py
@@ -1,6 +1,6 @@
 """Door Writer.
 
 Note to developers:
-Use this module to extend honeybee's Door writer for new plugins.
+Use this module to extend honeybee's Door writer for new extensions.
 (eg. adding `idf` to this module adds the method `Door.to.idf`)
 """

--- a/honeybee/writer/face.py
+++ b/honeybee/writer/face.py
@@ -1,6 +1,6 @@
 """Face Writer.
 
 Note to developers:
-Use this module to extend honeybee's Face writer for new plugins.
+Use this module to extend honeybee's Face writer for new extensions.
 (eg. adding `idf` to this module adds the method `Face.to.idf`)
 """

--- a/honeybee/writer/face.py
+++ b/honeybee/writer/face.py
@@ -1,0 +1,6 @@
+"""Face Writer.
+
+Note to developers:
+Use this module to extend honeybee's Face writer for new plugins.
+(eg. adding `idf` to this module adds the method `Face.to.idf`)
+"""

--- a/honeybee/writer/model.py
+++ b/honeybee/writer/model.py
@@ -1,6 +1,6 @@
 """Model Writer.
 
 Note to developers:
-Use this module to extend honeybee's Model writer for new plugins.
+Use this module to extend honeybee's Model writer for new extensions.
 (eg. adding `idf` to this module adds the method `Model.to.idf`)
 """

--- a/honeybee/writer/model.py
+++ b/honeybee/writer/model.py
@@ -1,0 +1,6 @@
+"""Model Writer.
+
+Note to developers:
+Use this module to extend honeybee's Model writer for new plugins.
+(eg. adding `idf` to this module adds the method `Model.to.idf`)
+"""

--- a/honeybee/writer/room.py
+++ b/honeybee/writer/room.py
@@ -1,6 +1,6 @@
 """Room Writer.
 
 Note to developers:
-Use this module to extend honeybee's Room writer for new plugins.
+Use this module to extend honeybee's Room writer for new extensions.
 (eg. adding `idf` to this module adds the method `Room.to.idf`)
 """

--- a/honeybee/writer/room.py
+++ b/honeybee/writer/room.py
@@ -1,0 +1,6 @@
+"""Room Writer.
+
+Note to developers:
+Use this module to extend honeybee's Room writer for new plugins.
+(eg. adding `idf` to this module adds the method `Room.to.idf`)
+"""

--- a/honeybee/writer/shade.py
+++ b/honeybee/writer/shade.py
@@ -1,6 +1,6 @@
 """Shade Writer.
 
 Note to developers:
-Use this module to extend honeybee's Shade writer for new plugins.
+Use this module to extend honeybee's Shade writer for new extensions.
 (eg. adding `idf` to this module adds the method `Shade.to.idf`)
 """

--- a/honeybee/writer/shade.py
+++ b/honeybee/writer/shade.py
@@ -1,0 +1,6 @@
+"""Shade Writer.
+
+Note to developers:
+Use this module to extend honeybee's Shade writer for new plugins.
+(eg. adding `idf` to this module adds the method `Shade.to.idf`)
+"""

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -350,3 +350,12 @@ def test_to_from_dict():
     new_ap = Aperture.from_dict(ap_dict)
     assert isinstance(new_ap, Aperture)
     assert new_ap.to_dict() == ap_dict
+
+
+def test_writer():
+    """Test the Aperture writer object."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    ap = Aperture.from_vertices('Rectangle Window', vertices)
+
+    writers = [mod for mod in dir(ap.to) if not mod.startswith('_')]
+    assert len(writers) == 0

--- a/tests/door_test.py
+++ b/tests/door_test.py
@@ -278,3 +278,12 @@ def test_to_from_dict():
     new_dr = Door.from_dict(dr_dict)
     assert isinstance(new_dr, Door)
     assert new_dr.to_dict() == dr_dict
+
+
+def test_writer():
+    """Test the Door writer object."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    door = Door.from_vertices('Rectangle Door', vertices)
+
+    writers = [mod for mod in dir(door.to) if not mod.startswith('_')]
+    assert len(writers) == 0

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -597,3 +597,13 @@ def test_to_from_dict():
     new_face = Face.from_dict(face_dict)
     assert isinstance(new_face, Face)
     assert new_face.to_dict() == face_dict
+
+
+def test_writer():
+    """Test the Face writer object."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    face = Face.from_vertices('test wall', vertices, face_types.wall,
+                              boundary_conditions.ground)
+
+    writers = [mod for mod in dir(face.to) if not mod.startswith('_')]
+    assert len(writers) == 0

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -797,3 +797,12 @@ def test_to_from_dict_methods():
     assert len(new_model.orphaned_shades) == 0
     assert len(new_model.orphaned_apertures) == 0
     assert len(new_model.orphaned_doors) == 0
+
+
+def test_writer():
+    """Test the Model writer object."""
+    room = Room.from_box('Tiny House Zone', 5, 10, 3)
+    model = Model('Tiny House', [room])
+
+    writers = [mod for mod in dir(model.to) if not mod.startswith('_')]
+    assert len(writers) == 0

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -505,3 +505,11 @@ def test_to_from_dict():
     new_room = Room.from_dict(room_dict)
     assert isinstance(new_room, Room)
     assert new_room.to_dict() == room_dict
+
+
+def test_writer():
+    """Test the Room writer object."""
+    room = Room.from_box('Shoe Box Zone', 5, 10, 3)
+
+    writers = [mod for mod in dir(room.to) if not mod.startswith('_')]
+    assert len(writers) == 0

--- a/tests/shade_test.py
+++ b/tests/shade_test.py
@@ -272,3 +272,12 @@ def test_to_from_dict():
     new_shd = Shade.from_dict(shd_dict)
     assert isinstance(new_shd, Shade)
     assert new_shd.to_dict() == shd_dict
+
+
+def test_writer():
+    """Test the Shade writer object."""
+    vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
+    shd = Shade.from_vertices('Rectangle Shade', vertices)
+
+    writers = [mod for mod in dir(shd.to) if not mod.startswith('_')]
+    assert len(writers) == 0


### PR DESCRIPTION
As we had it previously, there was no way to specify a separate writer for Rooms vs. Faces vs. Apertures, etc. This commit addresses this limitation by adding distinct classes under the `writer` module for each geometry object. A property under each writer that lists the `availabe_formats` to which objects can be written has also been added.