### PR TITLE
feat(adjacency): Output adjacency information from solve_adjacency

### DIFF
--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -384,43 +384,58 @@ class Face(_BaseWithShade):
             other_face: Another Face object to be set adjacent to this one.
             tolerance: The minimum distance between the center of two aperture
                 geometries at which they are condsidered adjacent. Default: 0.
+
+        Returns:
+            adjacent_apertures -- A list of tuples with each tuple containing 2 objects
+                for Apertures paired in the process of solving adjacency.
+            adjacent_doors -- A list of tuples with each tuple containing 2 objects
+                for Doors paired in the process of solving adjacency.
         """
         # check the inputs and the ability of the faces to be adjacent
         assert isinstance(other_face, Face), \
             'Expected honeybee Face. Got {}.'.format(type(other_face))
+
         # set the boundary conditions of the faces
         self._boundary_condition = boundary_conditions.surface(other_face)
         other_face._boundary_condition = boundary_conditions.surface(self)
+
         # set the apertures to be adjacent to one another
         assert len(self._apertures) == len(other_face._apertures), \
             'Number of apertures does not match between {} and {}.'.format(
                 self.name, other_face.name)
+        adjacent_apertures = []
         if len(self._apertures) > 0:
             found_adjacencies = 0
             for aper_1 in self._apertures:
                 for aper_2 in other_face._apertures:
                     if aper_1.center.distance_to_point(aper_2.center) <= tolerance:
                         aper_1.set_adjacency(aper_2)
+                        adjacent_apertures.append((aper_1, aper_2))
                         found_adjacencies += 1
                         break
             assert len(self._apertures) == found_adjacencies, \
                 'Not all apertures of {} were found to be adjacent to apertures in {}.' \
                 '\nTry increasing the tolerance.'.format(self.name, other_face.name)
+
         # set the doors to be adjacent to one another
         assert len(self._doors) == len(other_face._doors), \
             'Number of doors does not match between {} and {}.'.format(
                 self.name, other_face.name)
+        adjacent_doors = []
         if len(self._doors) > 0:
             found_adjacencies = 0
             for door_1 in self._doors:
                 for door_2 in other_face._doors:
                     if door_1.center.distance_to_point(door_2.center) <= tolerance:
                         door_1.set_adjacency(door_2)
+                        adjacent_doors.append((door_1, door_2))
                         found_adjacencies += 1
                         break
             assert len(self._doors) == found_adjacencies, \
                 'Not all doors of {} were found to be adjacent to doors in {}.' \
                 '\nTry increasing the tolerance.'.format(self.name, other_face.name)
+
+        return adjacent_apertures, adjacent_doors
 
     def apertures_by_ratio(self, ratio, tolerance=0):
         """Add apertures to this Face given a ratio of aperture area to facea area.

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -549,7 +549,24 @@ class Room(_BaseWithShade):
             rooms: A list of rooms for which adjacencies will be solved.
             tolerance: The minimum difference between the coordinate values of two
                 faces at which they can be considered centered adjacent.
+
+        Returns:
+            adjacent_faces -- A list of tuples with each tuple containing 2 objects for
+                Faces paired in the process of solving adjacency. This data can be
+                used to assign custom properties to the new adjacent Faces (like
+                making all adjacencies an AirWall face type or assigning custom
+                materials/construcitons).
+            adjacent_apertures -- A list of tuples with each tuple containing 2 objects
+                for Apertures paired in the process of solving adjacency.
+            adjacent_doors -- A list of tuples with each tuple containing 2 objects
+                for Doors paired in the process of solving adjacency.
         """
+        # lists of adjacencies to track
+        adjacent_faces = []
+        adjacent_apertures = []
+        adjacent_doors = []
+
+        # solve all adjacencies between rooms
         for i, room_1 in enumerate(rooms):
             try:
                 for room_2 in rooms[i + 1:]:
@@ -558,10 +575,15 @@ class Room(_BaseWithShade):
                             if not isinstance(face_2.boundary_condition, Surface):
                                 if face_1.geometry.is_centered_adjacent(
                                         face_2.geometry, tolerance):
-                                    face_1.set_adjacency(face_2)
+                                    adj_aps, adj_drs = face_1.set_adjacency(face_2)
+                                    adjacent_faces.append((face_1, face_2))
+                                    adjacent_apertures.extend(adj_aps)
+                                    adjacent_doors.extend(adj_drs)
                                     break
             except IndexError:
                 pass  # we have reached the end of the list of zones
+
+        return adjacent_faces, adjacent_apertures, adjacent_doors
 
     @property
     def to(self):

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -453,12 +453,15 @@ def test_solve_adjacency():
     assert room_south[1].boundary_condition == boundary_conditions.outdoors
     assert room_north[3].boundary_condition == boundary_conditions.outdoors
 
-    Room.solve_adjacency([room_south, room_north], 0.01)
+    adj_faces, adj_aps, adj_drs = Room.solve_adjacency([room_south, room_north], 0.01)
 
     assert isinstance(room_south[1].boundary_condition, Surface)
     assert isinstance(room_north[3].boundary_condition, Surface)
     assert room_south[1].boundary_condition.boundary_condition_object == room_north[3].name
     assert room_north[3].boundary_condition.boundary_condition_object == room_south[1].name
+    assert len(adj_faces) == 1
+    assert len(adj_aps) == 0
+    assert len(adj_drs) == 0
 
 
 def test_solve_adjacency_aperture():
@@ -471,7 +474,7 @@ def test_solve_adjacency_aperture():
     assert room_south[1].apertures[0].boundary_condition == boundary_conditions.outdoors
     assert room_north[3].apertures[0].boundary_condition == boundary_conditions.outdoors
 
-    Room.solve_adjacency([room_south, room_north], 0.01)
+    adj_faces, adj_aps, adj_drs = Room.solve_adjacency([room_south, room_north], 0.01)
 
     assert isinstance(room_south[1].apertures[0].boundary_condition, Surface)
     assert isinstance(room_north[3].apertures[0].boundary_condition, Surface)
@@ -479,6 +482,9 @@ def test_solve_adjacency_aperture():
         room_north[3].apertures[0].name
     assert room_north[3].apertures[0].boundary_condition.boundary_condition_object == \
         room_south[1].apertures[0].name
+    assert len(adj_faces) == 1
+    assert len(adj_aps) == 1
+    assert len(adj_drs) == 0
 
 
 def test_to_dict():


### PR DESCRIPTION
After deliberating a bit on different ways to do this, it seems best to just return the information about the adjacencies that were found during the solve_adjacency run. This way, the information can be used to assign custom properties to the newly-adjacent faces, apertures and doors. For example, assigning custom interior materials/constructions or setting all new adjacent faces to be air walls.