### PR TITLE
frat(from_polyface): Improve naming convention in Room.from_polyface

### DIFF
--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -133,7 +133,7 @@ class Room(_BaseWithShade):
             'Expected ladybug_geometry Polyface3D. Got {}'.format(type(polyface))
         faces = []
         for i, face in enumerate(polyface.faces):
-            faces.append(Face('{}_Face{}'.format(name, i), face,
+            faces.append(Face('{}..Face{}'.format(name, i), face,
                               get_type_from_normal(face.normal, roof_angle, floor_angle),
                               get_bc_from_position(face.boundary, ground_depth)))
         room = cls(name, faces)


### PR DESCRIPTION
I am just making a style change here for a single line of code, which helps with some dragonfly-core features I am working on now. So I am just going to merge this one in.