### PR TITLE
feat(room): Add bounding box check to solve adjacency

### DIFF
--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -532,12 +532,8 @@ class Aperture(_BaseWithShade):
         base['name'] = self.name
         base['display_name'] = self.display_name
         base['properties'] = self.properties.to_dict(abridged, included_prop)
-
-        if 'energy' in base['properties']:
-            base['geometry'] = self._geometry.to_dict(False, True)  # enforce upper-left
-        else:
-            base['geometry'] = self._geometry.to_dict(False)
-
+        enforce_upper_left = True if 'energy' in base['properties'] else False
+        base['geometry'] = self._geometry.to_dict(False, enforce_upper_left)
         base['is_operable'] = self.is_operable
         if isinstance(self.boundary_condition, Outdoors) and 'energy' in base['properties']:
             base['boundary_condition'] = self.boundary_condition.to_dict(full=True)

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -337,12 +337,8 @@ class Door(_Base):
         base['name'] = self.name
         base['display_name'] = self.display_name
         base['properties'] = self.properties.to_dict(abridged, included_prop)
-
-        if 'energy' in base['properties']:
-            base['geometry'] = self._geometry.to_dict(False, True)  # enforce upper-left
-        else:
-            base['geometry'] = self._geometry.to_dict(False)
-
+        enforce_upper_left = True if 'energy' in base['properties'] else False
+        base['geometry'] = self._geometry.to_dict(False, enforce_upper_left)
         base['is_glass'] = self.is_glass
         if isinstance(self.boundary_condition, Outdoors) and \
                 'energy' in base['properties']:

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -890,10 +890,8 @@ class Face(_BaseWithShade):
         base['name'] = self.name
         base['display_name'] = self.display_name
         base['properties'] = self.properties.to_dict(abridged, included_prop)
-        if 'energy' in base['properties']:
-            base['geometry'] = self._geometry.to_dict(False, True)  # enforce upper-left
-        else:
-            base['geometry'] = self._geometry.to_dict(False)
+        enforce_upper_left = True if 'energy' in base['properties'] else False
+        base['geometry'] = self._geometry.to_dict(False, enforce_upper_left)
 
         base['face_type'] = self.type.name
         if isinstance(self.boundary_condition, Outdoors) and 'energy' in base['properties']:

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -52,7 +52,7 @@ class Room(_BaseWithShade):
             faces: A list or tuple of honeybee Face objects that together form the
                 closed volume of a room.
             tolerance: The maximum difference between x, y, and z values
-                at which vertices of adjacent facesare considered equivalent. This is
+                at which vertices of adjacent faces are considered equivalent. This is
                 used in determining whether the faces form a closed volume. Default
                 is None, which makes no attempt to evaluate whether the Room volume
                 is closed.
@@ -102,7 +102,7 @@ class Room(_BaseWithShade):
         assert data['type'] == 'Room', 'Expected Room dictionary. ' \
             'Got {}.'.format(data['type'])
 
-        room = Room(data['name'], [Face.from_dict(f_dict) for f_dict in data['faces']])
+        room = cls(data['name'], [Face.from_dict(f_dict) for f_dict in data['faces']])
         if 'display_name' in data and data['display_name'] is not None:
             room._display_name = data['display_name']
         if 'multiplier' in data and data['multiplier'] is not None:
@@ -440,13 +440,14 @@ class Room(_BaseWithShade):
     def check_solid(self, tolerance, angle_tolerance, raise_exception=True):
         """Check whether the Room is a closed solid to within the input tolerances.
 
-        tolerance: tolerance: The maximum difference between x, y, and z values
-            at which face vertices are considered equivalent. This is used in
-            determining whether the faces form a closed volume.
-        angle_tolerance: The max angle difference in degrees that vertices are
-            allowed to differ from one another in order to consider them colinear.
-        raise_exception: Boolean to note whether a ValueError should be raised
-            if the room geometry does not form a closed solid.
+        Args:
+            tolerance: tolerance: The maximum difference between x, y, and z values
+                at which face vertices are considered equivalent. This is used in
+                determining whether the faces form a closed volume.
+            angle_tolerance: The max angle difference in degrees that vertices are
+                allowed to differ from one another in order to consider them colinear.
+            raise_exception: Boolean to note whether a ValueError should be raised
+                if the room geometry does not form a closed solid.
         """
         if self._geometry is not None and self.geometry.is_solid:
             return True
@@ -571,6 +572,9 @@ class Room(_BaseWithShade):
         for i, room_1 in enumerate(rooms):
             try:
                 for room_2 in rooms[i + 1:]:
+                    if not Polyface3D.overlapping_bounding_boxes(
+                            room_1.geometry, room_2.geometry, tolerance):
+                        continue  # no overlap in bounding box; adjacency impossible
                     for face_1 in room_1._faces:
                         for face_2 in room_2._faces:
                             if not isinstance(face_2.boundary_condition, Surface):

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -257,10 +257,8 @@ class Shade(_Base):
         base['name'] = self.name
         base['display_name'] = self.display_name
         base['properties'] = self.properties.to_dict(abridged, included_prop)
-        if 'energy' in base['properties']:
-            base['geometry'] = self._geometry.to_dict(False, True)  # enforce upper-left
-        else:
-            base['geometry'] = self._geometry.to_dict(False)
+        enforce_upper_left = True if 'energy' in base['properties'] else False
+        base['geometry'] = self._geometry.to_dict(False, enforce_upper_left)
         return base
 
     def __copy__(self):

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -179,7 +179,7 @@ def test_average_orientation():
     face_4 = Face('Face 4', Face3D(pts_4), boundary_condition=boundary_conditions.ground)
     face_5 = Face('Face 5', Face3D(pts_5), boundary_condition=boundary_conditions.ground)
     face_6 = Face('Face 6', Face3D(pts_6))
-    room = Room('PAssive Solar Earthship',
+    room = Room('Passive Solar Earthship',
                 [face_1, face_2, face_3, face_4, face_5, face_6], 0.01, 1)
 
     assert room.average_orientation() == 180


### PR DESCRIPTION
I can see that this improves the speed of the calculation to more than double what it was previously. Given this, I think we should definitely implement some type of bounding box check on the intersect masses workflows.