### PR TITLE
feat(rename): Add rename method to all objects

### DIFF
--- a/honeybee/_base.py
+++ b/honeybee/_base.py
@@ -47,7 +47,7 @@ class _Base(object):
         """Get object properties, including Radiance, Energy and other properties."""
         return self._properties
     
-    def rename(self, prefix):
+    def add_prefix(self, prefix):
         """Change the name of this object by inserting a prefix.
         
         This is particularly useful in workflows where you duplicate and edit
@@ -60,7 +60,7 @@ class _Base(object):
                 and display_name. It is recommended that this name be short to
                 avoid maxing out the 100 allowable characters for honeybee names.
         """
-        self.name = '{}{}'.format(prefix, self.display_name)
+        self.name = '{}_{}'.format(prefix, self.display_name)
 
     def duplicate(self):
         """Get a copy of this object."""

--- a/honeybee/_base.py
+++ b/honeybee/_base.py
@@ -46,6 +46,21 @@ class _Base(object):
     def properties(self):
         """Get object properties, including Radiance, Energy and other properties."""
         return self._properties
+    
+    def rename(self, prefix):
+        """Change the name of this object by inserting a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms) since all objects
+        within a Model must have unique names.
+
+        Args:
+            prefix: Text that will be inserted at the start of this object's name
+                and display_name. It is recommended that this name be short to
+                avoid maxing out the 100 allowable characters for honeybee names.
+        """
+        self.name = '{}{}'.format(prefix, self.display_name)
 
     def duplicate(self):
         """Get a copy of this object."""

--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -175,7 +175,7 @@ class _BaseWithShade(_Base):
         for ishd in self._indoor_shades:
             ishd.scale(factor, origin)
     
-    def _rename_shades(self, prefix):
+    def _add_prefix_shades(self, prefix):
         """Change the name of all child shades by inserting a prefix.
 
         Args:
@@ -183,9 +183,9 @@ class _BaseWithShade(_Base):
                 and display_name.
         """
         for shade in self._outdoor_shades:
-            shade.rename(prefix)
+            shade.add_prefix(prefix)
         for shade in self._indoor_shades:
-            shade.rename(prefix)
+            shade.add_prefix(prefix)
 
     def _check_planar_shades(self, tolerance, raise_exception=True):
         """Check that all of the child shades are planar."""

--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -174,6 +174,18 @@ class _BaseWithShade(_Base):
             oshd.scale(factor, origin)
         for ishd in self._indoor_shades:
             ishd.scale(factor, origin)
+    
+    def _rename_shades(self, prefix):
+        """Change the name of all child shades by inserting a prefix.
+
+        Args:
+            prefix: Text that will be inserted at the start of this shades' name
+                and display_name.
+        """
+        for shade in self._outdoor_shades:
+            shade.rename(prefix)
+        for shade in self._indoor_shades:
+            shade.rename(prefix)
 
     def _check_planar_shades(self, tolerance, raise_exception=True):
         """Check that all of the child shades are planar."""

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -198,6 +198,23 @@ class Aperture(_BaseWithShade):
     def perimeter(self):
         """Get the perimeter of the aperture."""
         return self._geometry.perimeter
+    
+    def rename(self, prefix):
+        """Change the name of this object and all child objects by inserting a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms) since all objects
+        within a Model must have unique names.
+
+        Args:
+            prefix: Text that will be inserted at the start of this object's
+                (and child objects') name and display_name. It is recommended
+                that this name be short to avoid maxing out the 100 allowable
+                characters for honeybee names.
+        """
+        self.name = '{}{}'.format(prefix, self.display_name)
+        self._rename_shades(prefix)
 
     def set_adjacency(self, other_aperture):
         """Set this aperture to be adjacent to another.
@@ -285,8 +302,8 @@ class Aperture(_BaseWithShade):
         Args:
             depth: A number for the extrusion depth.
             indoor: Boolean for whether the extrusion should be generated facing the
-                opposite direction of the aperture normal (typically meaning
-                indoor geometry). Default: False.
+                opposite direction of the aperture normal and added to the Aperture's
+                indoor_shades instead of outdoor_shades. Default: False.
             base_name: Optional base name for the shade objects. If None, the default
                 is InBorder or OutBorder depending on whether indoor is True.
         """

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -199,7 +199,7 @@ class Aperture(_BaseWithShade):
         """Get the perimeter of the aperture."""
         return self._geometry.perimeter
     
-    def rename(self, prefix):
+    def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
         
         This is particularly useful in workflows where you duplicate and edit
@@ -213,8 +213,8 @@ class Aperture(_BaseWithShade):
                 that this name be short to avoid maxing out the 100 allowable
                 characters for honeybee names.
         """
-        self.name = '{}{}'.format(prefix, self.display_name)
-        self._rename_shades(prefix)
+        self.name = '{}_{}'.format(prefix, self.display_name)
+        self._add_prefix_shades(prefix)
 
     def set_adjacency(self, other_aperture):
         """Set this aperture to be adjacent to another.
@@ -249,11 +249,14 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default is 0, which will always yeild an overhang.
             base_name: Optional base name for the shade objects. If None, the default
                 is InOverhang or OutOverhang depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         if base_name is None:
             base_name = 'InOverhang' if indoor else 'OutOverhang'
-        self.louvers_by_count(1, depth, angle=angle, indoor=indoor,
-                              tolerance=tolerance, base_name=base_name)
+        return self.louvers_by_count(1, depth, angle=angle, indoor=indoor,
+                                     tolerance=tolerance, base_name=base_name)
 
     def right_fin(self, depth, angle=0, indoor=False, tolerance=0, base_name=None):
         """Add a single vertical fin on the right side of this Aperture.
@@ -269,11 +272,15 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default is 0, which will always yeild a fin.
             base_name: Optional base name for the shade objects. If None, the default
                 is InRightFin or OutRightFin depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         if base_name is None:
             base_name = 'InRightFin' if indoor else 'OutRightFin'
-        self.louvers_by_count(1, depth, angle=angle, contour_vector=Vector3D(1, 0, 0),
-                              indoor=indoor, tolerance=tolerance, base_name=base_name)
+        return self.louvers_by_count(
+            1, depth, angle=angle, contour_vector=Vector3D(1, 0, 0),
+            indoor=indoor, tolerance=tolerance, base_name=base_name)
 
     def left_fin(self, depth, angle=0, indoor=False, tolerance=0, base_name=None):
         """Add a single vertical fin on the left side of this Aperture.
@@ -289,12 +296,16 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default is 0, which will always yeild a fin.
             base_name: Optional base name for the shade objects. If None, the default
                 is InLeftFin or OutLeftFin depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         if base_name is None:
             base_name = 'InLeftFin' if indoor else 'OutLeftFin'
-        self.louvers_by_count(1, depth, angle=angle, contour_vector=Vector3D(1, 0, 0),
-                              flip_start_side=True, indoor=indoor,
-                              tolerance=tolerance, base_name=base_name)
+        return self.louvers_by_count(
+            1, depth, angle=angle, contour_vector=Vector3D(1, 0, 0),
+            flip_start_side=True, indoor=indoor, tolerance=tolerance,
+            base_name=base_name)
 
     def extruded_border(self, depth, indoor=False, base_name=None):
         """Add a series of Shade objects to this Aperture that form an extruded border.
@@ -306,6 +317,9 @@ class Aperture(_BaseWithShade):
                 indoor_shades instead of outdoor_shades. Default: False.
             base_name: Optional base name for the shade objects. If None, the default
                 is InBorder or OutBorder depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         extru_vec = self.normal if indoor is False else self.normal.reverse()
         extru_vec = extru_vec * depth
@@ -332,6 +346,7 @@ class Aperture(_BaseWithShade):
             self.add_indoor_shades(extrusion)
         else:
             self.add_outdoor_shades(extrusion)
+        return extrusion
 
     def louvers_by_count(self, louver_count, depth, offset=0, angle=0,
                          contour_vector=Vector3D(0, 0, 1), flip_start_side=False,
@@ -358,6 +373,9 @@ class Aperture(_BaseWithShade):
                 no matter how small.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         assert louver_count > 0, 'louver_count must be greater than 0.'
         angle = math.radians(angle)
@@ -376,6 +394,7 @@ class Aperture(_BaseWithShade):
             self.add_indoor_shades(louvers)
         else:
             self.add_outdoor_shades(louvers)
+        return louvers
 
     def louvers_by_distance_between(
             self, distance, depth, offset=0, angle=0, contour_vector=Vector3D(0, 0, 1),
@@ -402,6 +421,9 @@ class Aperture(_BaseWithShade):
                 no matter how small.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         angle = math.radians(angle)
         louvers = []
@@ -419,6 +441,7 @@ class Aperture(_BaseWithShade):
             self.add_indoor_shades(louvers)
         else:
             self.add_outdoor_shades(louvers)
+        return louvers
 
     def move(self, moving_vec):
         """Move this Aperture along a vector.

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -294,6 +294,27 @@ class Face(_BaseWithShade):
             return 'South'
         else:
             return 'West'
+    
+    def rename(self, prefix):
+        """Change the name of this object and all child objects by inserting a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms) since all objects
+        within a Model must have unique names.
+
+        Args:
+            prefix: Text that will be inserted at the start of this object's
+                (and child objects') name and display_name. It is recommended
+                that this name be short to avoid maxing out the 100 allowable
+                characters for honeybee names.
+        """
+        self.name = '{}{}'.format(prefix, self.display_name)
+        for ap in self._apertures:
+            ap.rename(prefix)
+        for dr in self._doors:
+            dr.rename(prefix)
+        self._rename_shades(prefix)
 
     def remove_sub_faces(self):
         """Remove all apertures and doors from the face."""

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -295,7 +295,7 @@ class Face(_BaseWithShade):
         else:
             return 'West'
     
-    def rename(self, prefix):
+    def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
         
         This is particularly useful in workflows where you duplicate and edit
@@ -309,12 +309,12 @@ class Face(_BaseWithShade):
                 that this name be short to avoid maxing out the 100 allowable
                 characters for honeybee names.
         """
-        self.name = '{}{}'.format(prefix, self.display_name)
+        self.name = '{}_{}'.format(prefix, self.display_name)
         for ap in self._apertures:
-            ap.rename(prefix)
+            ap.add_prefix(prefix)
         for dr in self._doors:
-            dr.rename(prefix)
-        self._rename_shades(prefix)
+            dr.add_prefix(prefix)
+        self._add_prefix_shades(prefix)
 
     def remove_sub_faces(self):
         """Remove all apertures and doors from the face."""
@@ -463,6 +463,8 @@ class Face(_BaseWithShade):
     def apertures_by_ratio(self, ratio, tolerance=0):
         """Add apertures to this Face given a ratio of aperture area to facea area.
 
+        Note that this method removes any existing apertures on the Face.
+
         This method attempts to generate as few apertures as necessary to meet the ratio.
         Note that this method will remove all existing apertures and doors on this face.
 
@@ -494,6 +496,8 @@ class Face(_BaseWithShade):
                                      horizontal_separation, vertical_separation=0,
                                      tolerance=0):
         """Add apertures to this face given a ratio of aperture area to face area.
+
+        Note that this method removes any existing apertures on the Face.
 
         This function is virtually equivalent to the apertures_by_ratio method but
         any rectangular portions of this face will produce customizable rectangular
@@ -555,6 +559,9 @@ class Face(_BaseWithShade):
             aperture_name: Optional name for the aperture. If None, the default name
                 will follow the convention "[face_name]_Glz[count]" where [count]
                 is one more than the current numer of apertures in the face.
+        
+        Returns:
+            The new Aperture object that has been generated.
 
         Usage:
             room = Room.from_box(3.0, 6.0, 3.2, 180)
@@ -586,6 +593,7 @@ class Face(_BaseWithShade):
         aperture = Aperture(name, ap_face)
         aperture._parent = self
         self._apertures.append(aperture)
+        return aperture
 
     def overhang(self, depth, angle=0, indoor=False, tolerance=0, base_name=None):
         """Add an overhang to this Face.
@@ -601,11 +609,14 @@ class Face(_BaseWithShade):
                 than the tolerance. Default is 0, which will always yeild an overhang.
             base_name: Optional base name for the shade objects. If None, the default
                 is InOverhang or OutOverhang depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         if base_name is None:
             base_name = 'InOverhang' if indoor else 'OutOverhang'
-        self.louvers_by_count(1, depth, angle=angle, indoor=indoor,
-                              tolerance=tolerance, base_name=base_name)
+        return self.louvers_by_count(1, depth, angle=angle, indoor=indoor,
+                                     tolerance=tolerance, base_name=base_name)
 
     def louvers_by_count(self, louver_count, depth, offset=0, angle=0,
                          contour_vector=Vector3D(0, 0, 1), flip_start_side=False,
@@ -632,6 +643,9 @@ class Face(_BaseWithShade):
                 no matter how small.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         assert louver_count > 0, 'louver_count must be greater than 0.'
         angle = math.radians(angle)
@@ -650,6 +664,7 @@ class Face(_BaseWithShade):
             self.add_indoor_shades(louvers)
         else:
             self.add_outdoor_shades(louvers)
+        return louvers
 
     def louvers_by_distance_between(
             self, distance, depth, offset=0, angle=0, contour_vector=Vector3D(0, 0, 1),
@@ -676,6 +691,9 @@ class Face(_BaseWithShade):
                 no matter how small.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
+        
+        Returns:
+            A list of the new Shade objects that have been generated.
         """
         angle = math.radians(angle)
         louvers = []
@@ -692,6 +710,7 @@ class Face(_BaseWithShade):
             self.add_indoor_shades(louvers)
         else:
             self.add_outdoor_shades(louvers)
+        return louvers
 
     def move(self, moving_vec):
         """Move this Face along a vector.

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -319,7 +319,7 @@ class Room(_BaseWithShade):
                 areas += face.area
         return orientations / areas if areas != 0 else None
     
-    def rename(self, prefix):
+    def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
         
         This is particularly useful in workflows where you duplicate and edit
@@ -333,10 +333,10 @@ class Room(_BaseWithShade):
                 that this name be short to avoid maxing out the 100 allowable
                 characters for honeybee names.
         """
-        self.name = '{}{}'.format(prefix, self.display_name)
+        self.name = '{}_{}'.format(prefix, self.display_name)
         for face in self._faces:
-            face.rename(prefix)
-        self._rename_shades(prefix)
+            face.add_prefix(prefix)
+        self._add_prefix_shades(prefix)
 
 
     def remove_indoor_furniture(self):

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -318,6 +318,26 @@ class Room(_BaseWithShade):
                 orientations += face.horizontal_orientation(north_vector) * face.area
                 areas += face.area
         return orientations / areas if areas != 0 else None
+    
+    def rename(self, prefix):
+        """Change the name of this object and all child objects by inserting a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms) since all objects
+        within a Model must have unique names.
+
+        Args:
+            prefix: Text that will be inserted at the start of this object's
+                (and child objects') name and display_name. It is recommended
+                that this name be short to avoid maxing out the 100 allowable
+                characters for honeybee names.
+        """
+        self.name = '{}{}'.format(prefix, self.display_name)
+        for face in self._faces:
+            face.rename(prefix)
+        self._rename_shades(prefix)
+
 
     def remove_indoor_furniture(self):
         """Remove all indoor furniture assigned to this Room.

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -67,13 +67,13 @@ def test_aperture_duplicate():
         assert pt != ap_2.vertices[i]
 
 
-def test_aperture_rename():
-    """Test the aperture rename method."""
+def test_aperture_add_prefix():
+    """Test the aperture add_prefix method."""
     pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
     aperture = Aperture('Rectangle Window', Face3D(pts_1))
     aperture.extruded_border(0.1)
     prefix = 'New'
-    aperture.rename(prefix)
+    aperture.add_prefix(prefix)
 
     assert aperture.name.startswith(prefix)
     for shd in aperture.shades:

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -67,6 +67,19 @@ def test_aperture_duplicate():
         assert pt != ap_2.vertices[i]
 
 
+def test_aperture_rename():
+    """Test the aperture rename method."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    aperture = Aperture('Rectangle Window', Face3D(pts_1))
+    aperture.extruded_border(0.1)
+    prefix = 'New'
+    aperture.rename(prefix)
+
+    assert aperture.name.startswith(prefix)
+    for shd in aperture.shades:
+        assert shd.name.startswith(prefix)
+
+
 def test_aperture_overhang():
     """Test the creation of an overhang for Aperture objects."""
     pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -135,15 +135,15 @@ def test_cardinal_direction():
     assert face_4.cardinal_direction() == 'East'
 
 
-def test_face_rename():
-    """Test the face rename method."""
+def test_face_add_prefix():
+    """Test the face add_prefix method."""
     face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
     ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
     face = Face('Test_Roof', face_face3d)
     aperture = Aperture('Test_Skylight', ap_face3d)
     face.add_aperture(aperture)
     prefix = 'New'
-    face.rename(prefix)
+    face.add_prefix(prefix)
 
     assert face.name.startswith(prefix)
     for ap in face.apertures:
@@ -154,7 +154,7 @@ def test_face_rename():
     face = Face('Test_Roof', face_face3d)
     door = Door('Test_Trap_Door', ap_face3d)
     face.add_door(door)
-    face.rename(prefix)
+    face.add_prefix(prefix)
 
     for dr in face.doors:
         assert dr.name.startswith(prefix)

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -135,6 +135,30 @@ def test_cardinal_direction():
     assert face_4.cardinal_direction() == 'East'
 
 
+def test_face_rename():
+    """Test the face rename method."""
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    face = Face('Test_Roof', face_face3d)
+    aperture = Aperture('Test_Skylight', ap_face3d)
+    face.add_aperture(aperture)
+    prefix = 'New'
+    face.rename(prefix)
+
+    assert face.name.startswith(prefix)
+    for ap in face.apertures:
+        assert ap.name.startswith(prefix)
+    
+    face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))
+    ap_face3d = Face3D.from_rectangle(2, 2, Plane(o=Point3D(2, 2, 3)))
+    face = Face('Test_Roof', face_face3d)
+    door = Door('Test_Trap_Door', ap_face3d)
+    face.add_door(door)
+    face.rename(prefix)
+
+    for dr in face.doors:
+        assert dr.name.startswith(prefix)
+
 def test_add_remove_door():
     """Test the adding and removing of an door to a Face."""
     face_face3d = Face3D.from_rectangle(10, 10, Plane(o=Point3D(0, 0, 3)))

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -186,15 +186,15 @@ def test_average_orientation():
     assert room.average_orientation(Vector2D(1, 0)) == 90
 
 
-def test_room_rename():
-    """Test the room rename method."""
+def test_room_add_prefix():
+    """Test the room add_prefix method."""
     room = Room.from_box('ShoeBoxZone', 5, 10, 3)
     south_face = room[3]
     south_face.apertures_by_ratio(0.5, 0.01)
     table_geo = Face3D.from_rectangle(2, 2, Plane(o=Point3D(1.5, 4, 1)))
     room.add_indoor_shade(Shade('Table', table_geo))
     prefix = 'New'
-    room.rename(prefix)
+    room.add_prefix(prefix)
 
     assert room.name.startswith(prefix)
     for face in room.faces:

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -186,6 +186,25 @@ def test_average_orientation():
     assert room.average_orientation(Vector2D(1, 0)) == 90
 
 
+def test_room_rename():
+    """Test the room rename method."""
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3)
+    south_face = room[3]
+    south_face.apertures_by_ratio(0.5, 0.01)
+    table_geo = Face3D.from_rectangle(2, 2, Plane(o=Point3D(1.5, 4, 1)))
+    room.add_indoor_shade(Shade('Table', table_geo))
+    prefix = 'New'
+    room.rename(prefix)
+
+    assert room.name.startswith(prefix)
+    for face in room.faces:
+        assert face.name.startswith(prefix)
+        for ap in face.apertures:
+            assert ap.name.startswith(prefix)
+    for shd in room.shades:
+        assert shd.name.startswith(prefix)
+
+
 def test_room_multiplier():
     """Test the room multiplier."""
     room = Room.from_box('ShoeBoxZone', 5, 10, 3)


### PR DESCRIPTION
This method will ease the cases where someone duplicates and edits a starting object and then wants to combine it with the original object into one Model (like making a model of repeated rooms) since all objects within a Model must have unique names.