### PR TITLE
fix(add_prefix): Add the prefix to Surface boundary conditions

### DIFF
--- a/honeybee/_base.py
+++ b/honeybee/_base.py
@@ -46,21 +46,6 @@ class _Base(object):
     def properties(self):
         """Get object properties, including Radiance, Energy and other properties."""
         return self._properties
-    
-    def add_prefix(self, prefix):
-        """Change the name of this object by inserting a prefix.
-        
-        This is particularly useful in workflows where you duplicate and edit
-        a starting object and then want to combine it with the original object
-        into one Model (like making a model of repeated rooms) since all objects
-        within a Model must have unique names.
-
-        Args:
-            prefix: Text that will be inserted at the start of this object's name
-                and display_name. It is recommended that this name be short to
-                avoid maxing out the 100 allowable characters for honeybee names.
-        """
-        self.name = '{}_{}'.format(prefix, self.display_name)
 
     def duplicate(self):
         """Get a copy of this object."""

--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -210,7 +210,7 @@ class Surface(_BoundaryCondition):
         the second object will be the parent Face of the sub-face and the third
         object will be the parent Room of the adjacent sub-face.
         """
-        return tuple(self._boundary_condition_objects)
+        return self._boundary_condition_objects
 
     @property
     def boundary_condition_object(self):

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -193,6 +193,26 @@ class Door(_Base):
     def perimeter(self):
         """Get the perimeter of the door."""
         return self._geometry.perimeter
+    
+    def add_prefix(self, prefix):
+        """Change the name of this object by inserting a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms) since all objects
+        within a Model must have unique names.
+
+        Args:
+            prefix: Text that will be inserted at the start of this object's name
+                and display_name. It is recommended that this name be short to
+                avoid maxing out the 100 allowable characters for honeybee names.
+        """
+        self.name = '{}_{}'.format(prefix, self.display_name)
+        if isinstance(self._boundary_condition, Surface):
+            new_bc_objs = ('{}_{}'.format(prefix, adj_name) for adj_name
+                           in self._boundary_condition._boundary_condition_objects)
+            self._boundary_condition = Surface(new_bc_objs, True)
+
 
     def set_adjacency(self, other_door):
         """Set this door to be adjacent to another (and vice versa).

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -315,6 +315,10 @@ class Face(_BaseWithShade):
         for dr in self._doors:
             dr.add_prefix(prefix)
         self._add_prefix_shades(prefix)
+        if isinstance(self._boundary_condition, Surface):
+            new_bc_objs = ('{}_{}'.format(prefix, adj_name) for adj_name
+                           in self._boundary_condition._boundary_condition_objects)
+            self._boundary_condition = Surface(new_bc_objs, False)
 
     def remove_sub_faces(self):
         """Remove all apertures and doors from the face."""

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -132,6 +132,21 @@ class Shade(_Base):
     def perimeter(self):
         """Get the perimeter of the shade."""
         return self._geometry.perimeter
+    
+    def add_prefix(self, prefix):
+        """Change the name of this object by inserting a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms) since all objects
+        within a Model must have unique names.
+
+        Args:
+            prefix: Text that will be inserted at the start of this object's name
+                and display_name. It is recommended that this name be short to
+                avoid maxing out the 100 allowable characters for honeybee names.
+        """
+        self.name = '{}_{}'.format(prefix, self.display_name)
 
     def move(self, moving_vec):
         """Move this Shade along a vector.


### PR DESCRIPTION
I realized that the original method will not work as intended unless the prefix is also added to Surface boundary condition objects. This should not make it possible to duplicate objects, add a prefix, and then not have to re-solve adjacency before adding them to a Model.