### PR TITLE
feat(orientation): Add module to handle orientation subdivision

### DIFF
--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -215,21 +215,21 @@ class Aperture(_BaseWithShade):
     def cardinal_direction(self, north_vector=Vector2D(0, 1)):
         """Get text description for the cardinal direction that the aperture is pointing.
 
-        Will be one of the following: ('North', 'East', 'South', 'West')
+        Will be one of the following: ('North', 'NorthEast', 'East', 'SouthEast',
+        'South', 'SouthWest', 'West', 'NorthWest').
 
         Args:
             north_vector: A ladybug_geometry Vector2D for the north direction.
                 Default is the Y-axis (0, 1).
         """
         orient = self.horizontal_orientation(north_vector)
-        if orient <= 45 or orient > 315:
-            return 'North'
-        elif orient <= 135:
-            return 'East'
-        elif orient <= 225:
-            return 'South'
-        else:
-            return 'West'
+        orient_text = ('North', 'NorthEast', 'East', 'SouthEast', 'South',
+                       'SouthWest', 'West', 'NorthWest')
+        angles = (22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5)
+        for i, ang in enumerate(angles):
+            if orient < ang:
+                return orient_text[i]
+        return orient_text[0]
     
     def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -5,6 +5,7 @@ from .properties import DoorProperties
 from .boundarycondition import boundary_conditions, Outdoors, Surface
 import honeybee.writer.door as writer
 
+from ladybug_geometry.geometry2d.pointvector import Vector2D
 from ladybug_geometry.geometry3d.pointvector import Point3D
 from ladybug_geometry.geometry3d.face import Face3D
 
@@ -193,6 +194,37 @@ class Door(_Base):
     def perimeter(self):
         """Get the perimeter of the door."""
         return self._geometry.perimeter
+    
+    def horizontal_orientation(self, north_vector=Vector2D(0, 1)):
+        """Get a number between 0 and 360 for the orientation of the door in degrees.
+
+        0 = North, 90 = East, 180 = South, 270 = West
+
+        Args:
+            north_vector: A ladybug_geometry Vector2D for the north direction.
+                Default is the Y-axis (0, 1).
+        """
+        return math.degrees(
+            north_vector.angle_clockwise(Vector2D(self.normal.x, self.normal.y)))
+
+    def cardinal_direction(self, north_vector=Vector2D(0, 1)):
+        """Get text description for the cardinal direction that the door is pointing.
+
+        Will be one of the following: ('North', 'NorthEast', 'East', 'SouthEast',
+        'South', 'SouthWest', 'West', 'NorthWest').
+
+        Args:
+            north_vector: A ladybug_geometry Vector2D for the north direction.
+                Default is the Y-axis (0, 1).
+        """
+        orient = self.horizontal_orientation(north_vector)
+        orient_text = ('North', 'NorthEast', 'East', 'SouthEast', 'South',
+                       'SouthWest', 'West', 'NorthWest')
+        angles = (22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5)
+        for i, ang in enumerate(angles):
+            if orient < ang:
+                return orient_text[i]
+        return orient_text[0]
     
     def add_prefix(self, prefix):
         """Change the name of this object by inserting a prefix.

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -279,21 +279,21 @@ class Face(_BaseWithShade):
     def cardinal_direction(self, north_vector=Vector2D(0, 1)):
         """Get text description for the cardinal direction that the face is pointing.
 
-        Will be one of the following: ('North', 'East', 'South', 'West')
+        Will be one of the following: ('North', 'NorthEast', 'East', 'SouthEast',
+        'South', 'SouthWest', 'West', 'NorthWest').
 
         Args:
             north_vector: A ladybug_geometry Vector2D for the north direction.
                 Default is the Y-axis (0, 1).
         """
         orient = self.horizontal_orientation(north_vector)
-        if orient <= 45 or orient > 315:
-            return 'North'
-        elif orient <= 135:
-            return 'East'
-        elif orient <= 225:
-            return 'South'
-        else:
-            return 'West'
+        orient_text = ('North', 'NorthEast', 'East', 'SouthEast', 'South',
+                       'SouthWest', 'West', 'NorthWest')
+        angles = (22.5, 67.5, 112.5, 157.5, 202.5, 247.5, 292.5, 337.5)
+        for i, ang in enumerate(angles):
+            if orient < ang:
+                return orient_text[i]
+        return orient_text[0]
     
     def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.

--- a/honeybee/orientation.py
+++ b/honeybee/orientation.py
@@ -1,0 +1,126 @@
+"""Collection of utilites for assigning different properties based on orientation.
+
+The functions here are meant to be adaptable to splitting up the compass based on
+however many bins the user desires, though the most common arrangement is likely
+to be a list of 4 values for North, East South, and West.
+
+Usage:
+    # list of constructions + materials to apply to faces of different orientations
+    ep_constructions = [constr_north, constr_east, constr_south, constr_west]
+    rad_materials = [mat_north, mat_east, mat_south, mat_west]
+
+    # check that the inputs align with one another
+    all_inputs = [ep_constructions, rad_materials]
+    all_inputs, num_orient = check_matching_inputs(all_inputs)
+
+    # assign proeprties based on orientation
+    angles = angles_from_num_orient(num_orient)
+    for face in hb_faces:
+        orient_i = face_orient_index(face, angles)
+        if orient_i is not None:
+            constr, mat = inputs_by_index(orient_i, all_inputs)
+            face.properties.energy.construction = constr
+            face.properties.radiance.modifier = mat
+"""
+from ladybug_geometry.geometry2d.pointvector import Vector2D
+
+
+def angles_from_num_orient(num_subdivisions=4):
+    """Get a list of angles based on the number of compass subdividsions.
+    
+    Args:
+        num_subdivisions: An integer for the number of times that the compass
+            should be subdivided. Default: 4, which will yield angles for North,
+            East South, and West.
+
+    Returns:
+        A list of angles in degrees with a length of the num_subdivisions, which
+        denote the boundaries of each orientation category.
+    """
+    step = 360.0 / num_subdivisions
+    start = step / 2.0
+    angles = []
+    while start < 360:
+        angles.append(start)
+        start += step
+    return angles
+
+
+def face_orient_index(face, angles, north_vector=Vector2D(0, 1)):
+    """Get the index to be used for a given face/aperture orientation from an angle list.
+    
+    Args:
+        face: A honeybee Face or Aperture object.
+        angles: A list of angles that denote the boundaries of each orientation
+            category.
+        north_vector: An optional ladybug_geometry Vector2D for the north direction.
+            Default is the Y-axis (0, 1).
+    
+    Returns:
+        An integer for the index used to assign properties to the object of the
+        input orientation. Will be None if the input Face or Aperture is perfectly
+        horizontal.
+    """
+    try:
+        return orient_index(face.horizontal_orientation(north_vector), angles)
+    except ZeroDivisionError:  # input face is perfectly horizontal
+        return None
+
+
+def orient_index(orientation, angles):
+    """Get the index to be used for a given face/aperture orientation from an angle list.
+    
+    Args:
+        orientation: The horizontal cardinal orientaion of the Face or Aperture
+            in degrees.
+        angles: A list of angles that denote the boundaries of each orientation
+            category.
+    
+    Returns:
+        An integer for the index used to assign properties to the object of the
+        input orientation.
+    """
+    for i, ang in enumerate(angles):
+        if orientation < ang:
+            return i
+    return 0
+
+
+def inputs_by_index(orientation_index, all_inputs):
+    """Get all of the inputs of a certain index from a list of all_inputs.
+    
+    This is useful for getting the set of all inputs that should be assigned to
+    a given Face or Aperture using its orientation_index.
+    """
+    return [inp[orientation_index] for inp in all_inputs]
+
+
+def check_matching_inputs(all_inputs, num_orient=None):
+    """Check that all orientation-specific inputs are coordinated.
+    
+    This means that each input is either a array of values to be aplied to each
+    orientation, which is has the same length as other orientation-specific arrays,
+    or it is a single value to be used for all orientations.
+
+    Args:
+        all_inputs: An array of arrays where each sub-array corresponds to an
+            orientation-specific input.
+        num_orient: An optional integer for the number of orientation categories
+            to be used. If None, the length of the longest input list in the
+            all_inputs will be used.
+    
+    Returns:
+        all_inputs -- The input all_inputs with all sub-arrays having the same length.
+        num_orient -- An integer for the number of orientations used in the check.
+    """
+    num_orient = max([len(inp) for inp in all_inputs]) if num_orient is None \
+            else num_orient
+    for i, param_list in enumerate(all_inputs):
+        if len(param_list) == 1:
+            all_inputs[i] = param_list * num_orient
+        else:
+            assert len(param_list) == num_orient, \
+                'The number of items in one of the inputs lists does not match the ' \
+                'others.\nPlease ensure that either the lists match or you put in '\
+                'a single value for all orientations.'
+    return all_inputs, num_orient

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -302,7 +302,7 @@ class Room(_BaseWithShade):
     def average_orientation(self, north_vector=Vector2D(0, 1)):
         """Get a number between 0 and 360 for the average orientation of exposed walls.
 
-        0 = North, 90 = East, 180 = South, 270 = West.  Wil be None if the zone has
+        0 = North, 90 = East, 180 = South, 270 = West.  Will be None if the zone has
         no exterior walls. Resulting value is weighted by the area of each of the
         wall faces.
 

--- a/tests/orientation_test.py
+++ b/tests/orientation_test.py
@@ -1,0 +1,43 @@
+from honeybee.orientation import angles_from_num_orient, face_orient_index, \
+    inputs_by_index, check_matching_inputs
+from honeybee.boundarycondition import boundary_conditions, Outdoors, Ground
+from honeybee.room import Room
+
+from ladybug_geometry.geometry3d.pointvector import Point3D
+
+
+def test_orientation_simple():
+    """Test the simple use of the orientation module."""
+    # create a Room to assign different propeties by orientation.
+    room = Room.from_box('ShoeBox', 5, 10, 3, 0, Point3D(0, 0, 3))
+
+    # list of bcs properties to apply to faces of different orientations
+    bcs = boundary_conditions
+    boundaries = [bcs.outdoors, bcs.ground, bcs.outdoors, bcs.ground]
+    ratios = [0.4, 0, 0.6, 0]
+
+    # check that the inputs align with one another
+    all_inputs = [boundaries, ratios]
+    all_inputs, num_orient = check_matching_inputs(all_inputs)
+
+    # assign proeprties based on orientation
+    angles = angles_from_num_orient(num_orient)
+    for face in room.faces:
+        orient_i = face_orient_index(face, angles)
+        if orient_i is not None:
+            bc, ratio = inputs_by_index(orient_i, all_inputs)
+            face.boundary_condition = bc
+            if ratio != 0:
+                face.apertures_by_ratio(ratio, 0.01)
+    
+    assert isinstance(room[1].boundary_condition, Outdoors)
+    assert isinstance(room[2].boundary_condition, Ground)
+    assert isinstance(room[3].boundary_condition, Outdoors)
+    assert isinstance(room[4].boundary_condition, Ground)
+
+    assert len(room[0].apertures) == 0
+    assert len(room[1].apertures) == 1
+    assert len(room[2].apertures) == 0
+    assert len(room[3].apertures) == 1
+    assert len(room[4].apertures) == 0
+    assert len(room[5].apertures) == 0


### PR DESCRIPTION
This new module constitutes all of the generic functions for assigning different properties based on Face or Aperture orientation.  I imagine that these will get applied all over honeybee and its extensions given how useful this type of automation is. And I know @mostapharoudsari mentioned in an earlier review that he felt these functions belonged in the core rather than repeated over several components.