### PR TITLE
style(config): Implement cleaner way to find default_simulation_folder

### DIFF
--- a/honeybee/config.py
+++ b/honeybee/config.py
@@ -117,10 +117,8 @@ class Folders(object):
         
         An attempt will be made to create the directory if it does not already exist.
         """
-        try:  # windows
-            sim_folder = os.path.join(os.environ['USERPROFILE'], 'honeybee')
-        except KeyError:  # mac and linux
-            sim_folder = os.path.join(os.environ['HOME'], 'honeybee')
+        home_folder = os.getenv('HOME') or os.path.expanduser('~')
+        sim_folder = os.path.join(home_folder, 'honeybee')
         if not os.path.isdir(sim_folder):
             try:
                 os.makedirs(sim_folder)


### PR DESCRIPTION
From my understanding, I think this code is less prone to errors and I have verified that it works on both Windows and Mac.