### PR TITLE
feat(add_prefix): Include option to add prefix to extension attributes

### DIFF
--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -246,6 +246,7 @@ class Aperture(_BaseWithShade):
                 characters for honeybee names.
         """
         self.name = '{}_{}'.format(prefix, self.display_name)
+        self.properties.add_prefix(prefix)
         self._add_prefix_shades(prefix)
         if isinstance(self._boundary_condition, Surface):
             new_bc_objs = ('{}_{}'.format(prefix, adj_name) for adj_name

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -240,6 +240,7 @@ class Door(_Base):
                 avoid maxing out the 100 allowable characters for honeybee names.
         """
         self.name = '{}_{}'.format(prefix, self.display_name)
+        self.properties.add_prefix(prefix)
         if isinstance(self._boundary_condition, Surface):
             new_bc_objs = ('{}_{}'.format(prefix, adj_name) for adj_name
                            in self._boundary_condition._boundary_condition_objects)

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -310,6 +310,7 @@ class Face(_BaseWithShade):
                 characters for honeybee names.
         """
         self.name = '{}_{}'.format(prefix, self.display_name)
+        self.properties.add_prefix(prefix)
         for ap in self._apertures:
             ap.add_prefix(prefix)
         for dr in self._doors:

--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -51,6 +51,36 @@ class _Properties(object):
                 import traceback
                 traceback.print_exc()
                 raise Exception('Failed to duplicate {}: {}'.format(var, e))
+    
+    def _add_prefix_extension_attr(self, prefix):
+        """Change the name extension attributes unique to this object by adding a prefix.
+        
+        This is particularly useful in workflows where you duplicate and edit
+        a starting object and then want to combine it with the original object
+        into one Model (like making a model of repeated rooms).
+        
+        Notably, this method only adds the prefix to extension attributes that must
+        be unique to the object and does not add the prefix to attributes that are
+        shared across several objects.
+
+        Args:
+            prefix: Text that will be inserted at the start of the extension attributes'
+                name. It is recommended that this name be short to avoid maxing
+                out the 100 allowable characters for honeybee names.
+        """
+        attr = [atr for atr in dir(self)
+                if not atr.startswith('_') and atr not in self._do_not_duplicate]
+
+        for atr in attr:
+            var = getattr(self, atr)
+            if not hasattr(var, 'add_prefix'):
+                continue
+            try:
+                var.add_prefix(prefix)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                raise Exception('Failed to add prefix to {}: {}'.format(var, e))
 
     def _add_extension_attr_to_dict(self, base, abridged, include):
         """Add attributes for extensions to the base dictionary.
@@ -224,6 +254,18 @@ class RoomProperties(_Properties):
 
         base = self._add_extension_attr_to_dict(base, abridged, include)
         return base
+    
+    def add_prefix(self, prefix):
+        """Change the name extension attributes unique to this object by adding a prefix.
+        
+        Notably, this method only adds the prefix to extension attributes that must
+        be unique to the Room (eg. single-room HVAC systems) and does not add the
+        prefix to attributes that are shared across several Rooms (eg. ConstructionSets).
+
+        Args:
+            prefix: Text that will be inserted at the start of extension attribute names.
+        """
+        self._add_prefix_extension_attr(prefix)
 
     def __repr__(self):
         """Properties representation."""
@@ -256,6 +298,18 @@ class FaceProperties(_Properties):
             {'type': 'FacePropertiesAbridged'}
         base = self._add_extension_attr_to_dict(base, abridged, include)
         return base
+
+    def add_prefix(self, prefix):
+        """Change the name extension attributes unique to this object by adding a prefix.
+        
+        Notably, this method only adds the prefix to extension attributes that must
+        be unique to the Face and does not add the prefix to attributes that are
+        shared across several Faces.
+
+        Args:
+            prefix: Text that will be inserted at the start of extension attribute names.
+        """
+        self._add_prefix_extension_attr(prefix)
 
     def __repr__(self):
         """Properties representation."""
@@ -290,6 +344,18 @@ class ShadeProperties(_Properties):
         base = self._add_extension_attr_to_dict(base, abridged, include)
         return base
 
+    def add_prefix(self, prefix):
+        """Change the name extension attributes unique to this object by adding a prefix.
+        
+        Notably, this method only adds the prefix to extension attributes that must
+        be unique to the Shade and does not add the prefix to attributes that are
+        shared across several Shades.
+
+        Args:
+            prefix: Text that will be inserted at the start of extension attribute names.
+        """
+        self._add_prefix_extension_attr(prefix)
+
     def __repr__(self):
         """Properties representation."""
         return 'ShadeProperties: {}'.format(self.host.display_name)
@@ -323,6 +389,18 @@ class ApertureProperties(_Properties):
         base = self._add_extension_attr_to_dict(base, abridged, include)
         return base
 
+    def add_prefix(self, prefix):
+        """Change the name extension attributes unique to this object by adding a prefix.
+        
+        Notably, this method only adds the prefix to extension attributes that must
+        be unique to the Aperture and does not add the prefix to attributes that are
+        shared across several Apertures.
+
+        Args:
+            prefix: Text that will be inserted at the start of extension attribute names.
+        """
+        self._add_prefix_extension_attr(prefix)
+
     def __repr__(self):
         """Properties representation."""
         return 'ApertureProperties: {}'.format(self.host.display_name)
@@ -355,6 +433,18 @@ class DoorProperties(_Properties):
 
         base = self._add_extension_attr_to_dict(base, abridged, include)
         return base
+
+    def add_prefix(self, prefix):
+        """Change the name extension attributes unique to this object by adding a prefix.
+        
+        Notably, this method only adds the prefix to extension attributes that must
+        be unique to the Door and does not add the prefix to attributes that are
+        shared across several Doors.
+
+        Args:
+            prefix: Text that will be inserted at the start of extension attribute names.
+        """
+        self._add_prefix_extension_attr(prefix)
 
     def __repr__(self):
         """Properties representation."""

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -334,6 +334,7 @@ class Room(_BaseWithShade):
                 characters for honeybee names.
         """
         self.name = '{}_{}'.format(prefix, self.display_name)
+        self.properties.add_prefix(prefix)
         for face in self._faces:
             face.add_prefix(prefix)
         self._add_prefix_shades(prefix)

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -147,6 +147,7 @@ class Shade(_Base):
                 avoid maxing out the 100 allowable characters for honeybee names.
         """
         self.name = '{}_{}'.format(prefix, self.display_name)
+        self.properties.add_prefix(prefix)
 
     def move(self, moving_vec):
         """Move this Shade along a vector.


### PR DESCRIPTION
The recent shift in the setup of HVAC systems has created a new situation that I am sure will arise again in the future. Specifically, when a user wants to change the name of an object and all of its sub-objects (like after duplicating and moving a Room to combine it with the original Room into one Model), there are also some extension attributes that should be renamed (like single-room HVAC systems). This commit adds in code to call such add_prefix methods on extension attributes if the method exists. If the method does not exist, the renaming process simply proceeds as usual.