### PR TITLE
feat(shade): Add property to track whether Shade is on the indoors

### DIFF
--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -57,6 +57,7 @@ class _BaseWithShade(_Base):
         """Remove all indoor shades assigned to this object."""
         for shade in self._indoor_shades:
             shade._parent = None
+            shade._is_indoor = False
         self._indoor_shades = []
 
     def add_outdoor_shade(self, shade):
@@ -73,6 +74,7 @@ class _BaseWithShade(_Base):
         """
         assert isinstance(shade, Shade), \
             'Expected Shade for outdoor_shade. Got {}.'.format(type(shade))
+        assert shade.parent is None, 'Shade cannot have more than one parent object.'
         shade._parent = self
         self._outdoor_shades.append(shade)
 
@@ -90,7 +92,9 @@ class _BaseWithShade(_Base):
         """
         assert isinstance(shade, Shade), \
             'Expected Shade for indoor_shade. Got {}.'.format(type(shade))
+        assert shade.parent is None, 'Shade cannot have more than one parent object.'
         shade._parent = self
+        shade._is_indoor = True
         self._indoor_shades.append(shade)
 
     def add_outdoor_shades(self, shades):
@@ -252,6 +256,7 @@ class _BaseWithShade(_Base):
             self._indoor_shades = [Shade.from_dict(sh) for sh in data['indoor_shades']]
             for ishd in self._indoor_shades:
                 ishd._parent = self
+                ishd._is_indoor = True
 
     def _duplicate_child_shades(self, new_object):
         """Add duplicated child shades to a duplcated new_object."""
@@ -261,3 +266,4 @@ class _BaseWithShade(_Base):
             oshd._parent = new_object
         for ishd in new_object._indoor_shades:
             ishd._parent = new_object
+            ishd._is_indoor = True

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -278,7 +278,8 @@ class Aperture(_BaseWithShade):
         Args:
             depth: A number for the overhang depth.
             angle: A number for the for an angle to rotate the overhang in degrees.
-                Default is 0 for no rotation.
+                Positive numbers indicate a downward rotation while negative numbers
+                indicate an upward rotation. Default is 0 for no rotation.
             indoor: Boolean for whether the overhang should be generated facing the
                 opposite direction of the aperture normal (typically meaning
                 indoor geometry). Default: False.
@@ -396,7 +397,8 @@ class Aperture(_BaseWithShade):
             offset: A number for the distance to louvers from this aperture.
                 Default is 0 for no offset.
             angle: A number for the for an angle to rotate the louvers in degrees.
-                Default is 0 for no rotation.
+                Positive numbers indicate a downward rotation while negative numbers
+                indicate an upward rotation. Default is 0 for no rotation.
             contour_vector: A Vector2D for the direction along which contours
                 are generated. This 2D vector will be interpreted into a 3D vector
                 within the plane of this Aperture. (0, 1) will usually generate
@@ -447,7 +449,8 @@ class Aperture(_BaseWithShade):
             offset: A number for the distance to louvers from this aperture.
                 Default is 0 for no offset.
             angle: A number for the for an angle to rotate the louvers in degrees.
-                Default is 0 for no rotation.
+                Positive numbers indicate a downward rotation while negative numbers
+                indicate an upward rotation. Default is 0 for no rotation.
             contour_vector: A Vector2D for the direction along which contours
                 are generated. This 2D vector will be interpreted into a 3D vector
                 within the plane of this Aperture. (0, 1) will usually generate
@@ -594,6 +597,9 @@ class Aperture(_BaseWithShade):
         Use this method to access Writer class to write the aperture in other formats.
 
         Usage:
+
+        .. code-block:: python
+
             aperture.to.idf(aperture) -> idf string.
             aperture.to.radiance(aperture) -> Radiance string.
         """

--- a/honeybee/config.py
+++ b/honeybee/config.py
@@ -3,6 +3,9 @@
 Import this into every module where access configurations are needed.
 
 Usage:
+
+.. code-block:: python
+
     from honeybee.config import folders
     print(folders.python_exe_path)
     print(folders.default_simulation_folder)

--- a/honeybee/extensionutil.py
+++ b/honeybee/extensionutil.py
@@ -41,10 +41,11 @@ def model_extension_dicts(data, extension_key, room_ext_dicts=[], face_ext_dicts
     if 'orphaned_apertures' in data:
         aperture_extension_dicts(data['orphaned_apertures'], extension_key,
                                  aperture_ext_dicts, shade_ext_dicts)
+    if 'orphaned_doors' in data:
+        door_extension_dicts(data['orphaned_doors'], extension_key, door_ext_dicts,
+                             shade_ext_dicts)
     if 'orphaned_shades' in data:
         shade_extension_dicts(data['orphaned_shades'], extension_key, shade_ext_dicts)
-    if 'orphaned_doors' in data:
-        door_extension_dicts(data['orphaned_doors'], extension_key, door_ext_dicts)
 
     return room_ext_dicts, face_ext_dicts, shade_ext_dicts, \
         aperture_ext_dicts, door_ext_dicts
@@ -67,10 +68,10 @@ def room_extension_dicts(room_list, extension_key, room_ext_dicts=[], face_ext_d
     """
     for room_dict in room_list:
         room_ext_dicts.append(room_dict['properties'][extension_key])
-        if 'outdoor_shades' in room_dict:
+        if 'outdoor_shades' in room_dict and room_dict['outdoor_shades'] is not None:
             shade_extension_dicts(room_dict['outdoor_shades'], extension_key,
                                   shade_ext_dicts)
-        if 'indoor_shades' in room_dict:
+        if 'indoor_shades' in room_dict and room_dict['indoor_shades'] is not None:
             shade_extension_dicts(room_dict['indoor_shades'], extension_key,
                                   shade_ext_dicts)
         face_extension_dicts(room_dict['faces'], extension_key, face_ext_dicts,
@@ -95,17 +96,18 @@ def face_extension_dicts(face_list, extension_key, face_ext_dicts=[],
     """
     for face_dict in face_list:
         face_ext_dicts.append(face_dict['properties'][extension_key])
-        if 'outdoor_shades' in face_dict:
+        if 'outdoor_shades' in face_dict and face_dict['outdoor_shades'] is not None:
             shade_extension_dicts(face_dict['outdoor_shades'], extension_key,
                                   shade_ext_dicts)
-        if 'indoor_shades' in face_dict:
+        if 'indoor_shades' in face_dict and face_dict['indoor_shades'] is not None:
             shade_extension_dicts(face_dict['indoor_shades'], extension_key,
                                   shade_ext_dicts)
-        if 'apertures' in face_dict:
+        if 'apertures' in face_dict and face_dict['apertures'] is not None:
             aperture_extension_dicts(face_dict['apertures'], extension_key,
                                      aperture_ext_dicts, shade_ext_dicts)
-        if 'doors' in face_dict:
-            door_extension_dicts(face_dict['doors'], extension_key, door_ext_dicts)
+        if 'doors' in face_dict and face_dict['doors'] is not None:
+            door_extension_dicts(face_dict['doors'], extension_key,
+                                 door_ext_dicts, shade_ext_dicts)
     return face_ext_dicts, shade_ext_dicts, aperture_ext_dicts, door_ext_dicts
 
 
@@ -138,14 +140,15 @@ def aperture_extension_dicts(aperture_list, extension_key, aperture_ext_dicts=[]
     """
     for ap_dict in aperture_list:
         aperture_ext_dicts.append(ap_dict['properties'][extension_key])
-        if 'outdoor_shades' in ap_dict:
+        if 'outdoor_shades' in ap_dict and ap_dict['outdoor_shades'] is not None:
             shade_extension_dicts(ap_dict['outdoor_shades'], extension_key, shade_ext_dicts)
-        if 'indoor_shades' in ap_dict:
+        if 'indoor_shades' in ap_dict and ap_dict['indoor_shades'] is not None:
             shade_extension_dicts(ap_dict['indoor_shades'], extension_key, shade_ext_dicts)
     return aperture_ext_dicts, shade_ext_dicts
 
 
-def door_extension_dicts(door_list, extension_key, door_ext_dicts=[]):
+def door_extension_dicts(door_list, extension_key, door_ext_dicts=[],
+                         shade_ext_dicts=[]):
     """Get all Door property dictionaires of an extension organized by geometry type.
 
     Args:
@@ -154,7 +157,12 @@ def door_extension_dicts(door_list, extension_key, door_ext_dicts=[]):
 
     Returns:
         door_ext_dicts: A list with Door extension property dictionaries.
+        shade_ext_dicts: A list with Shade extension property dictionaries.
     """
     for dr_dict in door_list:
         door_ext_dicts.append(dr_dict['properties'][extension_key])
-    return door_ext_dicts
+        if 'outdoor_shades' in dr_dict and dr_dict['outdoor_shades'] is not None:
+            shade_extension_dicts(dr_dict['outdoor_shades'], extension_key, shade_ext_dicts)
+        if 'indoor_shades' in dr_dict and dr_dict['indoor_shades'] is not None:
+            shade_extension_dicts(dr_dict['indoor_shades'], extension_key, shade_ext_dicts)
+    return door_ext_dicts, shade_ext_dicts

--- a/honeybee/orientation.py
+++ b/honeybee/orientation.py
@@ -5,6 +5,9 @@ however many bins the user desires, though the most common arrangement is likely
 to be a list of 4 values for North, East South, and West.
 
 Usage:
+
+.. code-block:: python
+
     # list of constructions + materials to apply to faces of different orientations
     ep_constructions = [constr_north, constr_east, constr_south, constr_west]
     rad_materials = [mat_north, mat_east, mat_south, mat_west]

--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -165,6 +165,9 @@ class ModelProperties(_Properties):
     Model properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         model = Model('New Elementary School', list_of_rooms)
         model.properties -> ModelProperties
         model.properties.radiance -> ModelRadianceProperties
@@ -233,6 +236,9 @@ class RoomProperties(_Properties):
     Room properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         room = Room('Bedroom', geometry)
         room.properties -> RoomProperties
         room.properties.radiance -> RoomRadianceProperties
@@ -278,6 +284,9 @@ class FaceProperties(_Properties):
     Face properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         face = Face('South Bedroom Wall', geometry)
         face.properties -> FaceProperties
         face.properties.radiance -> FaceRadianceProperties
@@ -322,6 +331,9 @@ class ShadeProperties(_Properties):
     Shade properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         shade = Shade('Deep Overhang', geometry)
         shade.properties -> ShadeProperties
         shade.properties.radiance -> ShadeRadianceProperties
@@ -367,6 +379,9 @@ class ApertureProperties(_Properties):
     Aperture properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         aperture = Aperture('Window to My Soul', geometry)
         aperture.properties -> ApertureProperties
         aperture.properties.radiance -> ApertureRadianceProperties
@@ -412,6 +427,9 @@ class DoorProperties(_Properties):
     Door properties. This class will be extended by extensions.
 
     Usage:
+
+    .. code-block:: python
+
         door = Door('Front Door', geometry)
         door.properties -> DoorProperties
         door.properties.radiance -> DoorRadianceProperties

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -378,6 +378,9 @@ class Room(_BaseWithShade):
                 the floor.
 
         Usage:
+
+        .. code-block:: python
+
             room = Room.from_box(3.0, 6.0, 3.2, 180)
             floor_mesh = room.generate_mesh_grid(0.5, 0.5, 1)
             test_points = floor_mesh[0].face_centroids
@@ -619,6 +622,9 @@ class Room(_BaseWithShade):
         Use this method to access Writer class to write the room in other formats.
 
         Usage:
+
+        .. code-block:: python
+
             room.to.idf(room) -> idf string.
             room.to.radiance(room) -> Radiance string.
         """

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -17,6 +17,7 @@ class Shade(_Base):
         * name
         * display_name
         * parent
+        * is_indoor
         * has_parent
         * geometry
         * vertices
@@ -26,7 +27,7 @@ class Shade(_Base):
         * area
         * perimeter
     """
-    __slots__ = ('_geometry', '_parent')
+    __slots__ = ('_geometry', '_parent', '_is_indoor')
 
     def __init__(self, name, geometry):
         """A single planar shade.
@@ -41,7 +42,8 @@ class Shade(_Base):
         assert isinstance(geometry, Face3D), \
             'Expected ladybug_geometry Face3D. Got {}'.format(type(geometry))
         self._geometry = geometry
-        self._parent = None  # _parent will be set when the Shade is added to a Room
+        self._parent = None  # _parent will be set when the Shade is added to an object
+        self._is_indoor = False  # this will be set by the _parent
 
         # initialize properties for extensions
         self._properties = ShadeProperties(self)
@@ -82,13 +84,25 @@ class Shade(_Base):
 
     @property
     def parent(self):
-        """Get the parent Room if assigned. None if not assigned."""
+        """Get the parent object if assigned. None if not assigned.
+        
+        The parent object can be either a Room, Face, Aperture or Door.
+        """
         return self._parent
 
     @property
     def has_parent(self):
-        """Get a boolean noting whether this Shade has a parent Room."""
+        """Get a boolean noting whether this Shade has a parent object."""
         return self._parent is not None
+    
+    @property
+    def is_indoor(self):
+        """Get a boolean for whether this Shade is on the indoors of its parent object.
+        
+        Note that, if there is no parent assigned to this Shade, this property will
+        be False.
+        """
+        return self._is_indoor
 
     @property
     def geometry(self):
@@ -252,6 +266,9 @@ class Shade(_Base):
         Use this method to access Writer class to write the shade in different formats.
 
         Usage:
+
+        .. code-block:: python
+
             shade.to.idf(shade) -> idf string.
             shade.to.radiance(shade) -> Radiance string.
         """

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -89,13 +89,15 @@ def test_aperture_overhang():
     aperture_2 = Aperture('Good Triangle Window', Face3D(pts_2))
     aperture_3 = Aperture('Bad Triangle Window', Face3D(pts_3))
     aperture_1.overhang(1, tolerance=0.01)
-    aperture_2.overhang(1, tolerance=0.01)
+    aperture_2.overhang(1, indoor=True, tolerance=0.01)
     aperture_3.overhang(1, tolerance=0.01)
     assert isinstance(aperture_1.outdoor_shades[0], Shade)
-    assert isinstance(aperture_2.outdoor_shades[0], Shade)
+    assert isinstance(aperture_2.indoor_shades[0], Shade)
     assert len(aperture_3.outdoor_shades) == 0
     assert aperture_1.outdoor_shades[0].has_parent
-    assert aperture_2.outdoor_shades[0].has_parent
+    assert aperture_2.indoor_shades[0].has_parent
+    assert not aperture_1.outdoor_shades[0].is_indoor
+    assert aperture_2.indoor_shades[0].is_indoor
 
 
 def test_aperture_fin():
@@ -111,6 +113,7 @@ def test_aperture_fin():
     assert len(aperture_1.outdoor_shades) == 2
     assert isinstance(aperture_1.outdoor_shades[0], Shade)
     assert aperture_1.outdoor_shades[0].has_parent
+    assert not aperture_1.outdoor_shades[0].is_indoor
     assert len(aperture_2.outdoor_shades) == 0
 
 
@@ -129,10 +132,14 @@ def test_aperture_extruded_border():
     assert len(aperture_1.shades) == 8
     assert aperture_1.outdoor_shades[0].center.y > 0
     assert aperture_1.outdoor_shades[0].has_parent
+    assert all(not shd.is_indoor for shd in aperture_1.outdoor_shades)
+    assert all(shd.is_indoor for shd in aperture_1.indoor_shades)
     assert len(aperture_2.shades) == 6
     assert aperture_2.outdoor_shades[0].center.y > 0
     assert aperture_1.indoor_shades[0].center.y < 0
     assert aperture_2.indoor_shades[0].center.y < 0
+    assert all(not shd.is_indoor for shd in aperture_2.outdoor_shades)
+    assert all(shd.is_indoor for shd in aperture_2.indoor_shades)
 
 
 def test_aperture_louvers_by_distance_between():

--- a/tests/door_test.py
+++ b/tests/door_test.py
@@ -1,5 +1,6 @@
 """Test the Door class."""
 from honeybee.door import Door
+from honeybee.shade import Shade
 from honeybee.boundarycondition import Outdoors
 
 from ladybug_geometry.geometry3d.face import Face3D
@@ -46,6 +47,39 @@ def test_door_from_vertices():
     assert door.perimeter == 8
     assert isinstance(door.boundary_condition, Outdoors)
     assert not door.has_parent
+
+
+def test_door_add_prefix():
+    """Test the door add_prefix method."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(1, 0, 3), Point3D(1, 0, 0))
+    door = Door.from_vertices('Test Door', pts)
+    door.overhang(1)
+    prefix = 'New'
+    door.add_prefix(prefix)
+
+    assert door.name.startswith(prefix)
+    for shd in door.shades:
+        assert shd.name.startswith(prefix)
+
+
+def test_door_overhang():
+    """Test the creation of an overhang for Door objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    pts_2 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 3))
+    pts_3 = (Point3D(0, 0, 0), Point3D(2, 0, 3), Point3D(4, 0, 0))
+    door_1 = Door('Rectangle Door', Face3D(pts_1))
+    door_2 = Door('Good Triangle Door', Face3D(pts_2))
+    door_3 = Door('Bad Triangle Door', Face3D(pts_3))
+    door_1.overhang(1, tolerance=0.01)
+    door_2.overhang(1, indoor=True, tolerance=0.01)
+    door_3.overhang(1, tolerance=0.01)
+    assert isinstance(door_1.outdoor_shades[0], Shade)
+    assert isinstance(door_2.indoor_shades[0], Shade)
+    assert len(door_3.outdoor_shades) == 0
+    assert door_1.outdoor_shades[0].has_parent
+    assert door_2.indoor_shades[0].has_parent
+    assert not door_1.outdoor_shades[0].is_indoor
+    assert door_2.indoor_shades[0].is_indoor
 
 
 def test_door_duplicate():

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -362,6 +362,18 @@ def test_apertures_by_ratio_rectangle():
     assert face.apertures[0].geometry.max.z - face.apertures[0].geometry.min.z == 2
 
 
+def test_apertures_by_width_height_rectangle():
+    """Test the adding of apertures by width/height."""
+    pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(10, 0, 3), Point3D(10, 0, 0))
+    face = Face('Test_Wall', Face3D(pts))
+    face.apertures_by_width_height_rectangle(2, 2, 0.5, 2.5, 0.01)
+
+    assert len(face.apertures) == 4
+    assert all(len(ap.geometry.vertices) == 4 for ap in face.apertures)
+    assert sum([ap.area for ap in face.apertures]) == pytest.approx(16, rel=1e-2)
+    assert face.punched_geometry.area == pytest.approx(30 - 16, rel=1e-2)
+
+
 def test_apertures_by_width_height():
     """Test the adding of apertures by width and height."""
     pts = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))

--- a/tests/shade_test.py
+++ b/tests/shade_test.py
@@ -24,6 +24,7 @@ def test_shade_init():
     assert shade.area == 3
     assert shade.perimeter == 8
     assert not shade.has_parent
+    assert not shade.is_indoor
 
 
 def test_shade_from_vertices():
@@ -41,6 +42,7 @@ def test_shade_from_vertices():
     assert shade.area == 3
     assert shade.perimeter == 8
     assert not shade.has_parent
+    assert not shade.is_indoor
 
 
 def test_shade_duplicate():


### PR DESCRIPTION
This is_indoor property is needed to correctly set up the ModifierSet on honeybee-radiance.

Also, as part of this commit, I am adding the ability to assign Shades to Doors. This has now come up enough times from more than one person that I've realized that I better implement it now while I still have a near-complete idea of all the other repositories affected by the change (another month or two and I don't think that I would be able to catch all of the places that will be incorrect as a result of this change). As far as I can tell, the following repos need to be changed with a PR that parallels this one:
* honeybee-energy (especially the Model objectand Model writer)
* honeybee-schema (including both Door schema and the Wiki)
* energy-model-measure (OpenStudio has no concept of assigning Shades to Doors but I'll figure something out)
* honeybee-grasshopper-core (most of the visualization components and  the component that assigns Shade to a parent)
* honeybee-grasshopper-energy (the components that assign constructions and schedules to shades)

Lastly, I added a new method to the Face to add repeating windows at a fixed width x height now that we have methods for this on ladybug_geometry. This doesn't require any parallel PRs in other repos but, at some point, I should probably add a WindowParameter object to Dragonfly that makes use of this new method.