### PR TITLE
fix(boundarycondition): Update based on recent schema change

### DIFF
--- a/honeybee/altnumber.py
+++ b/honeybee/altnumber.py
@@ -1,0 +1,47 @@
+"""Objects used as alternatives to various numerical properties."""
+
+
+class _AltNumber(object):
+    __slots__ = ()
+
+    def __init__(self):
+        pass
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+    
+    def to_dict(self):
+        """Get the object as a dictionary."""
+        return {'type': self.name}
+
+    def ToString(self):
+        return self.__repr__()
+
+    def __eq__(self, other):
+        return self.__class__ == other.__class__
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.name
+
+
+class NoLimit(_AltNumber):
+    """Object representing no limit to a certain numerical value."""
+    __slots__ = ()
+    pass
+
+
+class Autocalculate(_AltNumber):
+    """Object representing when a certain numerical value is automatically calculated.
+    
+    Typically, this means that the value is determined from other variables.
+    """
+    __slots__ = ()
+    pass
+
+
+no_limit = NoLimit()
+autocalculate = Autocalculate()

--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -1,5 +1,6 @@
 """Boundary Condition for Face, Aperture, Door."""
 from .typing import float_in_range, tuple_with_length
+from .altnumber import autocalculate
 
 import re
 
@@ -50,7 +51,7 @@ class Outdoors(_BoundaryCondition):
     __slots__ = ('_sun_exposure', '_wind_exposure', '_view_factor')
 
     def __init__(self, sun_exposure=True, wind_exposure=True,
-                 view_factor='autocalculate'):
+                 view_factor=autocalculate):
         """Initialize Outdoors boundary condition.
 
         Args:
@@ -59,8 +60,8 @@ class Outdoors(_BoundaryCondition):
             wind_exposure: A boolean noting whether the boundary is exposed to wind.
                 Default: True.
             view_factor: A number between 0 and 1 for the view factor to the ground.
-                This input can also be the word 'autocalculate' to have the view
-                factor automatically calculated.  Default: 'autocalculate'.
+                This input can also be an Autocalculate object to sigify that the view
+                factor automatically calculated.  Default: autocalculate.
         """
         assert isinstance(sun_exposure, bool), \
             'Input sun_exposure must be a Boolean. Got {}.'.format(type(sun_exposure))
@@ -68,9 +69,8 @@ class Outdoors(_BoundaryCondition):
         assert isinstance(wind_exposure, bool), \
             'Input wind_exposure must be a Boolean. Got {}.'.format(type(wind_exposure))
         self._wind_exposure = wind_exposure
-        if isinstance(view_factor, str) and \
-                (view_factor.lower() == 'autocalculate' or view_factor == ''):
-            self._view_factor = 'autocalculate'
+        if view_factor == autocalculate:
+            self._view_factor = autocalculate
         else:
             self._view_factor = float_in_range(
                 view_factor, 0.0, 1.0, 'view factor to ground')
@@ -86,8 +86,8 @@ class Outdoors(_BoundaryCondition):
             'condition. Got {}.'.format(data['type'])
         sun_exposure = True if 'sun_exposure' not in data else data['sun_exposure']
         wind_exposure = True if 'wind_exposure' not in data else data['wind_exposure']
-        view_factor = 'autocalculate' if 'view_factor' not in data else \
-            data['view_factor']
+        view_factor = autocalculate if 'view_factor' not in data or \
+            data['view_factor'] == autocalculate.to_dict() else data['view_factor']
         return cls(sun_exposure, wind_exposure, view_factor)
 
     @property
@@ -127,7 +127,8 @@ class Outdoors(_BoundaryCondition):
         if full:
             bc_dict['sun_exposure'] = self.sun_exposure
             bc_dict['wind_exposure'] = self.wind_exposure
-            bc_dict['view_factor'] = self.view_factor
+            bc_dict['view_factor'] = autocalculate.to_dict() if \
+                self.view_factor == autocalculate else self.view_factor
         return bc_dict
 
 

--- a/honeybee/facetype.py
+++ b/honeybee/facetype.py
@@ -100,7 +100,7 @@ class _FaceTypes(object):
                 ': {}'.format(face_type_name, list(self._type_name_dict.keys())))
     
     def _build_type_name_dict(self):
-        """Build a dictionary that can be used to lookup boundary conditions by name."""
+        """Build a dictionary that can be used to lookup face types by name."""
         attr = [atr for atr in dir(self) if not atr.startswith('_')]
         clean_attr = [re.sub(r'[\s_]', '', atr.lower()) for atr in attr]
         self._type_name_dict = {}

--- a/tests/boundary_condition_test.py
+++ b/tests/boundary_condition_test.py
@@ -1,6 +1,7 @@
 """test Face class."""
 from honeybee.boundarycondition import boundary_conditions, Outdoors, Surface, Ground
 from honeybee.room import Room
+from honeybee.altnumber import autocalculate
 
 import pytest
 
@@ -14,7 +15,7 @@ def test_outdoors_default():
     assert bc.sun_exposure_idf == 'SunExposed'
     assert bc.wind_exposure
     assert bc.wind_exposure_idf == 'WindExposed'
-    assert bc.view_factor == 'autocalculate'
+    assert bc.view_factor == autocalculate
 
 
 def test_outdoors_custom():
@@ -33,7 +34,7 @@ def test_outdoors_to_dict():
     assert outdict['type'] == 'Outdoors'
     assert outdict['sun_exposure']
     assert outdict['wind_exposure']
-    assert outdict['view_factor'] == 'autocalculate'
+    assert outdict['view_factor'] == autocalculate.to_dict()
     outdict = bc.to_dict(full=False)
     assert 'sun_exposure' not in outdict
     assert 'wind_exposure' not in outdict


### PR DESCRIPTION
This commit brings the library up-to-date with these recent changes in honeybee-schema:
https://github.com/ladybug-tools/honeybee-schema/pull/44

Only the to_dict methods have been changed and the Python objects still internally use strings for simplicity. An alternative approach could use classes for AutoCalculate, AutoSize and NoLimit and use them similarly to how the `facetype` module is used. A change like this would involve a bunch of edits in a lot of different places, though. @mostapharoudsari, what do you think?