### PR TITLE
Format docstrings for correct display in sphinx-generated bootstrap pages 

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,40 @@
+/*
+ * bootstrap-sphinx.css
+ * ~~~~~~~~~~~~~~~~~~~~
+ *
+ * Sphinx stylesheet -- Bootstrap theme.
+ */
+
+
+/* The code below is based on the bootstrap website sidebar */
+
+
+/* Show and affix the side nav when space allows it */
+@media screen and (min-width: 992px) {
+  .bs-sidenav .nav > .active > ul {
+    display: block;
+  }
+  /* Widen the fixed sidenav */
+  .bs-sidenav.affix,
+  .bs-sidenav.affix-bottom {
+    width: 292px;
+  }
+  .bs-sidenav.affix {
+    position: fixed; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom {
+    position: absolute; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom .bs-sidenav,
+  .bs-sidenav.affix .bs-sidenav {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  /* Widen the fixed sidenav again */
+  .bs-sidenav.affix-bottom,
+  .bs-sidenav.affix {
+    width: 360px;
+  }
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,107 @@
+{% extends "basic/layout.html" %}
+
+{% if theme_bootstrap_version == "3" %}
+  {% set bootstrap_version, navbar_version = "3.3.7", "" %}
+  {% set bs_span_prefix = "col-md-" %}
+{% else %}
+  {% set bootstrap_version, navbar_version = "2.3.2", "-2" %}
+  {% set bs_span_prefix = "span" %}
+{% endif %}
+
+{%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and sidebars %}
+
+{%- set bs_content_width = render_sidebar and "8" or "12"%}
+
+{%- block doctype -%}
+<!DOCTYPE html>
+{%- endblock %}
+
+{# Sidebar: Rework into our Bootstrap nav section. #}
+{% macro navBar() %}
+{% include "navbar" + navbar_version + ".html" %}
+{% endmacro %}
+
+{% if theme_bootstrap_version == "3" %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav" role="complementary">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% else %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav well" data-spy="affix">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% endif %}
+
+{%- block extrahead %}
+<meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
+<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-1.11.0.min.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-fix.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static', 1) + '/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js' }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/bootstrap-sphinx.js', 1) }} "></script>
+{% endblock %}
+
+{# Silence the sidebar's, relbar's #}
+{% block header %}{% endblock %}
+{% block relbar1 %}{% endblock %}
+{% block relbar2 %}{% endblock %}
+{% block sidebarsourcelink %}{% endblock %}
+
+{%- block content %}
+{{ navBar() }}
+<div class="container">
+  <div class="row">
+    {%- block sidebar1 %}{{ bsidebar() }}{% endblock %}
+    <div class="body {{ bs_span_prefix }}{{ bs_content_width }} content" role="main">
+      {% block body %}{% endblock %}
+    </div>
+    {% block sidebar2 %} {# possible location for sidebar #} {% endblock %}
+  </div>
+</div>
+{%- endblock %}
+
+{%- block footer %}
+<footer class="footer">
+  <div class="container">
+    <p class="pull-right">
+      <a href="#">Back to top</a>
+      {% if theme_source_link_position == "footer" %}
+        <br/>
+        {% include "sourcelink.html" %}
+      {% endif %}
+    </p>
+    <p>
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}<br/>
+      {%- else %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}<br/>
+      {%- endif %}
+    {%- endif %}
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>
+    {%- endif %}
+    {%- if show_sphinx %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}<br/>
+    {%- endif %}
+    </p>
+  </div>
+</footer>
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,11 +100,17 @@ html_theme_options = {
     # Fix navigation bar to top of page?
     # Values: "true" (default) or "false"
     'navbar_fixed_top': "true",
-	'navbar_pagenav': True,
+    'navbar_pagenav': True,
     'source_link_position': "nav",
-	'bootswatch_theme': "united",
+    'bootswatch_theme': "united",
     'bootstrap_version': "3",
-	}
+}
+
+# Bootstrap theme custom file paths (relative to this file)
+# Layout.html path (already added above, include if different)
+# templates_path = ['_templates']
+# Stylesheet path
+html_static_path = ["_static"]
 
 # on_rtd is whether we are on readthedocs.org
 # on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -117,7 +123,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+# html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -213,3 +219,20 @@ epub_exclude_files = ['search.html']
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# -- Options for autodoc extension --------------------------------------------
+autodoc_default_options = {
+    'inherited-members': True,
+}
+
+autodoc_member_order = 'groupwise'
+
+
+def setup(app):
+    """Run custom code with access to the Sphinx application object
+    Args:
+        app: the Sphinx application object
+    """
+
+    # Add bootstrap theme custom stylesheet
+    app.add_stylesheet("custom.css")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,8 +109,6 @@ html_theme_options = {
 # Bootstrap theme custom file paths (relative to this file)
 # Layout.html path (already added above, include if different)
 # templates_path = ['_templates']
-# Stylesheet path
-html_static_path = ["_static"]
 
 # on_rtd is whether we are on readthedocs.org
 # on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
@@ -123,7 +121,7 @@ html_static_path = ["_static"]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = []
+html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/honeybee/_base.py
+++ b/honeybee/_base.py
@@ -6,18 +6,17 @@ from .typing import valid_string
 class _Base(object):
     """A base class for all geometry objects.
 
+    Args:
+        name: Object name. Must be < 100 characters.
+
     Properties:
-        name
-        display_name
+        * name
+        * display_name
     """
     __slots__ = ('_name', '_display_name', '_properties')
 
     def __init__(self, name):
-        """Initialize base object.
-
-        Args:
-            name: Object name. Must be < 100 characters.
-        """
+        """Initialize base object."""
         self.name = name
         self._properties = None
 

--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -7,6 +7,9 @@ from .shade import Shade
 class _BaseWithShade(_Base):
     """A base class for all objects that can have Shades nested on them.
 
+    Args:
+        name: Object name. Must be < 100 characters.
+
     Properties:
         * name
         * display_name
@@ -18,11 +21,7 @@ class _BaseWithShade(_Base):
     __slots__ = ('_outdoor_shades', '_indoor_shades')
 
     def __init__(self, name):
-        """Initialize base with shade object.
-
-        Args:
-            name: Object name. Must be < 100 characters.
-        """
+        """Initialize base with shade object."""
         _Base.__init__(self, name)  # process the name
         self._outdoor_shades = []
         self._indoor_shades = []
@@ -178,7 +177,7 @@ class _BaseWithShade(_Base):
             oshd.scale(factor, origin)
         for ishd in self._indoor_shades:
             ishd.scale(factor, origin)
-    
+
     def _add_prefix_shades(self, prefix):
         """Change the name of all child shades by inserting a prefix.
 

--- a/honeybee/_lockable.py
+++ b/honeybee/_lockable.py
@@ -23,6 +23,9 @@ def lockable(cls):
     http://stackoverflow.com/questions/3603502/prevent-creating-new-attributes-outside-init
 
     Usage:
+
+    .. code-block:: python
+
         @lockable
         class Foo(object):
             def __init__(self):

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -16,6 +16,14 @@ import math
 class Aperture(_BaseWithShade):
     """A single planar Aperture in a Face.
 
+    Args:
+        name: Aperture name. Must be < 100 characters.
+        geometry: A ladybug-geometry Face3D.
+        boundary_condition: Boundary condition object (Outdoors, Surface).
+            Default: Outdoors.
+        is_operable: Boolean to note whether the Aperture can be opened for
+            ventilation. Default: False
+
     Properties:
         * name
         * display_name
@@ -37,16 +45,7 @@ class Aperture(_BaseWithShade):
     __slots__ = ('_geometry', '_parent', '_boundary_condition', '_is_operable')
 
     def __init__(self, name, geometry, boundary_condition=None, is_operable=False):
-        """A single planar aperture in a face.
-
-        Args:
-            name: Aperture name. Must be < 100 characters.
-            geometry: A ladybug-geometry Face3D.
-            boundary_condition: Boundary condition object (Outdoors, Surface).
-                Default: Outdoors.
-            is_operable: Boolean to note whether the Aperture can be opened for
-                ventilation. Default: False
-        """
+        """A single planar aperture in a face."""
         _BaseWithShade.__init__(self, name)  # process the name
 
         # process the geometry
@@ -199,7 +198,7 @@ class Aperture(_BaseWithShade):
     def perimeter(self):
         """Get the perimeter of the aperture."""
         return self._geometry.perimeter
-    
+
     def horizontal_orientation(self, north_vector=Vector2D(0, 1)):
         """Get a number between 0 and 360 for the orientation of the aperture in degrees.
 
@@ -230,10 +229,10 @@ class Aperture(_BaseWithShade):
             if orient < ang:
                 return orient_text[i]
         return orient_text[0]
-    
+
     def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated rooms) since all objects
@@ -287,7 +286,7 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InOverhang or OutOverhang depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -310,7 +309,7 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InRightFin or OutRightFin depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -334,7 +333,7 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InLeftFin or OutLeftFin depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -355,7 +354,7 @@ class Aperture(_BaseWithShade):
                 indoor_shades instead of outdoor_shades. Default: False.
             base_name: Optional base name for the shade objects. If None, the default
                 is InBorder or OutBorder depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -414,7 +413,7 @@ class Aperture(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -466,7 +465,7 @@ class Aperture(_BaseWithShade):
                 no matter how small.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """

--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -46,23 +46,23 @@ class _BoundaryCondition(object):
 
 
 class Outdoors(_BoundaryCondition):
-    """Outdoor boundary condition."""
+    """Outdoor boundary condition.
+
+    Args:
+        sun_exposure: A boolean noting whether the boundary is exposed to sun.
+            Default: True.
+        wind_exposure: A boolean noting whether the boundary is exposed to wind.
+            Default: True.
+        view_factor: A number between 0 and 1 for the view factor to the ground.
+            This input can also be an Autocalculate object to sigify that the view
+            factor automatically calculated.  Default: autocalculate.
+    """
 
     __slots__ = ('_sun_exposure', '_wind_exposure', '_view_factor')
 
     def __init__(self, sun_exposure=True, wind_exposure=True,
                  view_factor=autocalculate):
-        """Initialize Outdoors boundary condition.
-
-        Args:
-            sun_exposure: A boolean noting whether the boundary is exposed to sun.
-                Default: True.
-            wind_exposure: A boolean noting whether the boundary is exposed to wind.
-                Default: True.
-            view_factor: A number between 0 and 1 for the view factor to the ground.
-                This input can also be an Autocalculate object to sigify that the view
-                factor automatically calculated.  Default: autocalculate.
-        """
+        """Initialize Outdoors boundary condition."""
         assert isinstance(sun_exposure, bool), \
             'Input sun_exposure must be a Boolean. Got {}.'.format(type(sun_exposure))
         self._sun_exposure = sun_exposure
@@ -231,16 +231,16 @@ class Surface(_BoundaryCondition):
 
 
 class Ground(_BoundaryCondition):
-    """Ground boundary condition."""
+    """Ground boundary condition.
+    
+    Args:
+        data: A dictionary representaion of the boundary condition.
+    """
     __slots__ = ()
 
     @classmethod
     def from_dict(cls, data):
-        """Initialize Ground BoundaryCondition from a dictionary.
-
-        Args:
-            data: A dictionary representaion of the boundary condition.
-        """
+        """Initialize Ground BoundaryCondition from a dictionary."""
         assert data['type'] == 'Ground', 'Expected dictionary for Ground boundary ' \
             'condition. Got {}.'.format(data['type'])
         return cls()
@@ -266,14 +266,14 @@ class _BoundaryConditions(object):
 
     def surface(self, other_object, sub_face=False):
         """Get a Surface boundary condition.
-        
+
         Args:
             other_object: The other object that is adjacent to the one that will
                 bear this Surface boundary condition.
-            sub_face: Boolean to note whether 
+            sub_face: Boolean to note whether
         """
         return Surface.from_other_object(other_object, sub_face)
-    
+
     def by_name(self, bc_name):
         """Get a boundary condition object instance by its name.
 
@@ -292,7 +292,7 @@ class _BoundaryConditions(object):
             raise ValueError(
                 '"{}" is not a valid boundary condition name.\nChoose from the '
                 'following: {}'.format(bc_name, list(self._bc_name_dict.keys())))
-    
+
     def _build_bc_name_dict(self):
         """Build a dictionary that can be used to lookup boundary conditions by name."""
         attr = [atr for atr in dir(self) if not atr.startswith('_')]

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -16,6 +16,14 @@ import math
 class Door(_BaseWithShade):
     """A single planar Door in a Face.
 
+    Args:
+        name: Door name. Must be < 100 characters.
+        geometry: A ladybug-geometry Face3D.
+        boundary_condition: Boundary condition object (Outdoors, Surface, etc.).
+            Default: Outdoors.
+        is_glass: Boolean to note whether this object is a glass door as opposed
+            to an opaque door. Default: False.
+
     Properties:
         * name
         * display_name
@@ -37,16 +45,7 @@ class Door(_BaseWithShade):
     __slots__ = ('_geometry', '_parent', '_boundary_condition', '_is_glass')
 
     def __init__(self, name, geometry, boundary_condition=None, is_glass=False):
-        """A single planar Door in a Face.
-
-        Args:
-            name: Door name. Must be < 100 characters.
-            geometry: A ladybug-geometry Face3D.
-            boundary_condition: Boundary condition object (Outdoors, Surface, etc.).
-                Default: Outdoors.
-            is_glass: Boolean to note whether this object is a glass door as opposed
-                to an opaque door. Default: False.
-        """
+        """A single planar Door in a Face."""
         _BaseWithShade.__init__(self, name)  # process the name
 
         # process the geometry
@@ -198,7 +197,7 @@ class Door(_BaseWithShade):
     def perimeter(self):
         """Get the perimeter of the door."""
         return self._geometry.perimeter
-    
+
     def horizontal_orientation(self, north_vector=Vector2D(0, 1)):
         """Get a number between 0 and 360 for the orientation of the door in degrees.
 
@@ -229,10 +228,10 @@ class Door(_BaseWithShade):
             if orient < ang:
                 return orient_text[i]
         return orient_text[0]
-    
+
     def add_prefix(self, prefix):
         """Change the name of this object by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated rooms) since all objects
@@ -286,7 +285,7 @@ class Door(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InOverhang or OutOverhang depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """

--- a/honeybee/extensionutil.py
+++ b/honeybee/extensionutil.py
@@ -15,15 +15,21 @@ def model_extension_dicts(data, extension_key, room_ext_dicts, face_ext_dicts,
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        room_ext_dicts: A list of Room extension property dictionaries that
+        A tuple with five elements
+
+        -   room_ext_dicts: A list of Room extension property dictionaries that
             align with the serialized model.rooms.
-        face_ext_dicts: A list of Face extension property dictionaries that
+
+        -   face_ext_dicts: A list of Face extension property dictionaries that
             align with the serialized model.faces.
-        shade_ext_dicts: A list of Shade extension property dictionaries that
+
+        -   shade_ext_dicts: A list of Shade extension property dictionaries that
             align with the serialized model.shades.
-        aperture_ext_dicts: A list of Aperture extension property dictionaries that
+
+        -   aperture_ext_dicts: A list of Aperture extension property dictionaries that
             align with the serialized model.apertures.
-        door_ext_dicts: A list of Door extension property dictionaries that
+
+        -   door_ext_dicts: A list of Door extension property dictionaries that
             align with the serialized model.doors.
     """
     assert data['type'] == 'Model', \
@@ -60,11 +66,17 @@ def room_extension_dicts(room_list, extension_key, room_ext_dicts, face_ext_dict
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        room_ext_dicts: A list with the Room extension property dictionaries.
-        face_ext_dicts: A list with Face extension property dictionaries.
-        shade_ext_dicts: A list with Shade extension property dictionaries.
-        aperture_ext_dicts: A list with Aperture extension property dictionaries.
-        door_ext_dicts: A list with Door extension property dictionaries.
+        A tuple with five elements
+
+        -   room_ext_dicts: A list with the Room extension property dictionaries.
+
+        -   face_ext_dicts: A list with Face extension property dictionaries.
+
+        -   shade_ext_dicts: A list with Shade extension property dictionaries.
+
+        -   aperture_ext_dicts: A list with Aperture extension property dictionaries.
+
+        -   door_ext_dicts: A list with Door extension property dictionaries.
     """
     for room_dict in room_list:
         room_ext_dicts.append(room_dict['properties'][extension_key])
@@ -89,10 +101,15 @@ def face_extension_dicts(face_list, extension_key, face_ext_dicts,
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        face_ext_dicts: A list with Face extension property dictionaries.
-        shade_ext_dicts: A list with Shade extension property dictionaries.
-        aperture_ext_dicts: A list with Aperture extension property dictionaries.
-        door_ext_dicts: A list with Door extension property dictionaries.
+        A tuple with four elements
+
+        -   face_ext_dicts: A list with Face extension property dictionaries.
+
+        -   shade_ext_dicts: A list with Shade extension property dictionaries.
+
+        -   aperture_ext_dicts: A list with Aperture extension property dictionaries.
+
+        -   door_ext_dicts: A list with Door extension property dictionaries.
     """
     for face_dict in face_list:
         face_ext_dicts.append(face_dict['properties'][extension_key])
@@ -119,7 +136,7 @@ def shade_extension_dicts(shade_list, extension_key, shade_ext_dicts):
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        shade_ext_dicts: A list with Shade extension property dictionaries.
+        shade_ext_dicts -- A list with Shade extension property dictionaries.
     """
     for shd_dict in shade_list:
         shade_ext_dicts.append(shd_dict['properties'][extension_key])
@@ -135,8 +152,11 @@ def aperture_extension_dicts(aperture_list, extension_key, aperture_ext_dicts,
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        aperture_ext_dicts: A list with Aperture extension property dictionaries.
-        shade_ext_dicts: A list with Shade extension property dictionaries.
+        A tuple with two elements
+
+        -   aperture_ext_dicts: A list with Aperture extension property dictionaries.
+
+        -   shade_ext_dicts: A list with Shade extension property dictionaries.
     """
     for ap_dict in aperture_list:
         aperture_ext_dicts.append(ap_dict['properties'][extension_key])
@@ -156,8 +176,11 @@ def door_extension_dicts(door_list, extension_key, door_ext_dicts,
         extension_key: Text for the key of the extension (eg. "energy", "radiance").
 
     Returns:
-        door_ext_dicts: A list with Door extension property dictionaries.
-        shade_ext_dicts: A list with Shade extension property dictionaries.
+        A tuple with two elements
+
+        -   door_ext_dicts: A list with Door extension property dictionaries.
+
+        -   shade_ext_dicts: A list with Shade extension property dictionaries.
     """
     for dr_dict in door_list:
         door_ext_dicts.append(dr_dict['properties'][extension_key])

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -22,6 +22,18 @@ import math
 class Face(_BaseWithShade):
     """A single planar face.
 
+    Args:
+        name: Face name. Must be < 100 characters.
+        geometry: A ladybug-geometry Face3D.
+        type: Face type. Default varies depending on the direction that
+            the Face geometry is points.
+            RoofCeiling = pointing upward within 30 degrees
+            Wall = oriented vertically within +/- 60 degrees
+            Floor = pointing downward within 30 degrees
+        boundary_condition: Face boundary condition (Outdoors, Ground, etc.)
+            Default is Outdoors unless all vertices of the geometry lie
+            below the below the XY plane, in which case it will be set to Ground.
+
     Properties:
         * name
         * display_name
@@ -48,20 +60,7 @@ class Face(_BaseWithShade):
                  '_apertures', '_doors', '_type', '_boundary_condition')
 
     def __init__(self, name, geometry, type=None, boundary_condition=None):
-        """A single planar face.
-
-        Args:
-            name: Face name. Must be < 100 characters.
-            geometry: A ladybug-geometry Face3D.
-            type: Face type. Default varies depending on the direction that
-                the Face geometry is points.
-                RoofCeiling = pointing upward within 30 degrees
-                Wall = oriented vertically within +/- 60 degrees
-                Floor = pointing downward within 30 degrees
-            boundary_condition: Face boundary condition (Outdoors, Ground, etc.)
-                Default is Outdoors unless all vertices of the geometry lie
-                below the below the XY plane, in which case it will be set to Ground.
-        """
+        """A single planar face."""
         _BaseWithShade.__init__(self, name)  # process the name
 
         # process the geometry
@@ -144,7 +143,7 @@ class Face(_BaseWithShade):
     @property
     def type(self):
         """Get or set an object for Type of Face (ie. Wall, Floor, Roof).
-        
+
         Note that setting this property will reset extension attrributes on this
         Face to their default values.
         """
@@ -301,10 +300,10 @@ class Face(_BaseWithShade):
             if orient < ang:
                 return orient_text[i]
         return orient_text[0]
-    
+
     def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated rooms) since all objects
@@ -420,12 +419,13 @@ class Face(_BaseWithShade):
                 suitable for objects in meters.
 
         Returns:
-            dict: A dictionary of adjacency information with the following keys.
+            A dictionary of adjacency information with the following keys
 
-                * adjacent_apertures - A list of tuples with each tuple containing 2
-                    objects for Apertures paired in the process of solving adjacency.
-                * adjacent_doors - A list of tuples with each tuple containing 2
-                    objects for Doors paired in the process of solving adjacency.
+            -   adjacent_apertures - A list of tuples with each tuple containing 2
+                objects for Apertures paired in the process of solving adjacency.
+
+            -   adjacent_doors - A list of tuples with each tuple containing 2
+                objects for Doors paired in the process of solving adjacency.
         """
         # check the inputs and the ability of the faces to be adjacent
         assert isinstance(other_face, Face), \
@@ -635,7 +635,7 @@ class Face(_BaseWithShade):
             aperture_name: Optional name for the aperture. If None, the default name
                 will follow the convention "[face_name]_Glz[count]" where [count]
                 is one more than the current numer of apertures in the face.
-        
+
         Returns:
             The new Aperture object that has been generated.
 
@@ -689,7 +689,7 @@ class Face(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InOverhang or OutOverhang depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -726,7 +726,7 @@ class Face(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """
@@ -777,7 +777,7 @@ class Face(_BaseWithShade):
                 than the tolerance. Default: 0.01, suitable for objects in meters.
             base_name: Optional base name for the shade objects. If None, the default
                 is InShd or OutShd depending on whether indoor is True.
-        
+
         Returns:
             A list of the new Shade objects that have been generated.
         """

--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -21,6 +21,39 @@ import math
 class Model(_Base):
     """A collection of Rooms, Faces, Shades, Apertures, and Doors representing a model.
 
+    Args:
+        name: Model name. Must be < 100 characters.
+        rooms: A list of Room objects in the model.
+        orphaned_faces: A list of the Face objects in the model that lack
+            a parent Room. Note that orphaned Faces are not acceptable for
+            Models that are to be exported for energy simulation.
+        orphaned_shades: A list of the Shade objects in the model that lack
+            a parent.
+        orphaned_apertures: A list of the Aperture objects in the model that lack
+            a parent Face. Note that orphaned Apertures are not acceptable for
+            Models that are to be exported for energy simulation.
+        orphaned_doors: A list of the Door objects in the model that lack
+            a parent Face. Note that orphaned Doors are not acceptable for
+            Models that are to be exported for energy simulation.
+        north_angle: An number between 0 and 360 to set the clockwise north
+            direction in degrees. Default is 0.
+        units: Text for the units system in which the model geometry
+            exists. Default: 'Meters'. Choose from the following:
+
+            * Meters
+            * Millimeters
+            * Feet
+            * Inches
+            * Centimeters
+
+        tolerance: The maximum difference between x, y, and z values at which
+            vertices are considered equivalent. Zero indicates that no tolerance
+            checks should be performed. Default: 0.
+        angle_tolerance: The max angle difference in degrees that vertices are
+            allowed to differ from one another in order to consider them colinear.
+            Zero indicates that no angle tolerance checks should be performed.
+            Default: 0.
+
     Properties:
         * name
         * display_name
@@ -42,45 +75,13 @@ class Model(_Base):
     __slots__ = ('_rooms', '_orphaned_faces', '_orphaned_shades', '_orphaned_apertures',
                  '_orphaned_doors', '_north_angle', '_north_vector', '_units',
                  '_tolerance', '_angle_tolerance')
-    
+
     UNITS = ('Meters', 'Millimeters', 'Feet', 'Inches', 'Centimeters')
 
     def __init__(self, name, rooms=None, orphaned_faces=None, orphaned_shades=None,
                  orphaned_apertures=None, orphaned_doors=None, north_angle=0,
                  units='Meters', tolerance=0, angle_tolerance=0):
-        """A collection of Rooms, Faces, Apertures, and Doors for an entire model.
-
-        Args:
-            name: Model name. Must be < 100 characters.
-            rooms: A list of Room objects in the model.
-            orphaned_faces: A list of the Face objects in the model that lack
-                a parent Room. Note that orphaned Faces are not acceptable for
-                Models that are to be exported for energy simulation.
-            orphaned_shades: A list of the Shade objects in the model that lack
-                a parent.
-            orphaned_apertures: A list of the Aperture objects in the model that lack
-                a parent Face. Note that orphaned Apertures are not acceptable for
-                Models that are to be exported for energy simulation.
-            orphaned_doors: A list of the Door objects in the model that lack
-                a parent Face. Note that orphaned Doors are not acceptable for
-                Models that are to be exported for energy simulation.
-            north_angle: An number between 0 and 360 to set the clockwise north
-                direction in degrees. Default is 0.
-            units: Text for the units system in which the model geometry
-                exists. Default: 'Meters'. Choose from the following:
-                    * Meters
-                    * Millimeters
-                    * Feet
-                    * Inches
-                    * Centimeters
-            tolerance: The maximum difference between x, y, and z values at which
-                vertices are considered equivalent. Zero indicates that no tolerance
-                checks should be performed. Default: 0.
-            angle_tolerance: The max angle difference in degrees that vertices are
-                allowed to differ from one another in order to consider them colinear.
-                Zero indicates that no angle tolerance checks should be performed.
-                Default: 0.
-        """
+        """A collection of Rooms, Faces, Apertures, and Doors for an entire model."""
         self.name = name
         self.north_angle = north_angle
         self.units = units
@@ -172,11 +173,13 @@ class Model(_Base):
                 direction in degrees. Default is 0.
             units: Text for the units system in which the model geometry
                 exists. Default: 'Meters'. Choose from the following:
-                    * Meters
-                    * Millimeters
-                    * Feet
-                    * Inches
-                    * Centimeters
+
+                * Meters
+                * Millimeters
+                * Feet
+                * Inches
+                * Centimeters
+
             tolerance: The maximum difference between x, y, and z values at which
                 vertices are considered equivalent. Zero indicates that no tolerance
                 checks should be performed. Default: 0.
@@ -244,7 +247,7 @@ class Model(_Base):
     @property
     def tolerance(self):
         """Get or set a number for the max meaningful difference between x, y, z values.
-        
+
         This value should be in the Model's units. Zero indicates cases
         where no tolerance checks should be performed.
         """
@@ -257,7 +260,7 @@ class Model(_Base):
     @property
     def angle_tolerance(self):
         """Get or set a number for the max meaningful angle difference in degrees.
-        
+
         Face3D normal vectors differing by this amount are not considered parallel
         and Face3D segments that differ from 180 by this amount are not considered
         colinear. Zero indicates cases where no angle_tolerance checks should be
@@ -563,11 +566,12 @@ class Model(_Base):
         Args:
             units: Text for the units to which the Model geometry should be
                 converted. Default: Meters. Choose from the following:
-                    * Meters
-                    * Millimeters
-                    * Feet
-                    * Inches
-                    * Centimeters
+
+                * Meters
+                * Millimeters
+                * Feet
+                * Inches
+                * Centimeters
         """
         if self.units != units:
             scale_fac1 = self.conversion_factor_to_meters(self.units)
@@ -759,20 +763,24 @@ class Model(_Base):
         Apertures that all have 3 or 4 sides.
 
         Returns:
-            triangulated_apertures: A list of lists where each list is a set of
+            A tuple with two elements
+
+            -   triangulated_apertures: A list of lists where each list is a set of
                 triangle Apertures meant to replace an Aperture with more than
                 4 sides in the model.
-            parents_to_edit: An list of lists that parellels the triangulated_apertures
+
+            -   parents_to_edit: An list of lists that parellels the triangulated_apertures
                 in that each item represents an Aperture that has been triangulated
                 in the model. However, each of these lists holds between 1 and 3 values
                 for the names of the original aperture and parents of the aperture.
                 This information is intended to help edit parent faces that have had
                 their child faces triangulated. The 3 values are as follows:
-                    0 = The name of the original Aperture that was triangulated.
-                    1 = The name of the parent Face of the original Aperture
-                        (if it exists).
-                    2 = The name of the parent Room of the parent Face of the
-                        original Aperture (if it exists).
+
+                * 0 = The name of the original Aperture that was triangulated.
+                * 1 = The name of the parent Face of the original Aperture
+                  (if it exists).
+                * 2 = The name of the parent Room of the parent Face of the
+                  original Aperture (if it exists).
         """
         triangulated_apertures = []
         parents_to_edit = []
@@ -816,19 +824,23 @@ class Model(_Base):
         all have 3 or 4 sides.
 
         Returns:
-            triangulated_doors: A list of lists where each list is a set of triangle
+            A tuple with two elements
+
+            -   triangulated_doors: A list of lists where each list is a set of triangle
                 Doors meant to replace a Door with more than 4 sides in the model.
-            parents_to_edit: An list of lists that parellels the triangulated_doors
+
+            -   parents_to_edit: An list of lists that parellels the triangulated_doors
                 in that each item represents a Door that has been triangulated
                 in the model. However, each of these lists holds between 1 and 3 values
                 for the names of the original door and parents of the door.
                 This information is intended to help edit parent faces that have had
                 their child faces triangulated. The 3 values are as follows:
-                    0 = The name of the original Door that was triangulated.
-                    1 = The name of the parent Face of the original Door
-                        (if it exists).
-                    2 = The name of the parent Room of the parent Face of the
-                        original Door (if it exists).
+
+                * 0 = The name of the original Door that was triangulated.
+                * 1 = The name of the parent Face of the original Door
+                  (if it exists).
+                * 2 = The name of the parent Room of the parent Face of the
+                  original Door (if it exists).
         """
         triangulated_doors = []
         parents_to_edit = []
@@ -876,14 +888,18 @@ class Model(_Base):
                 to generate the new Aperture objects.
 
         Returns:
-            new_aps: A list of the new Aperture objects.
-            parent_edit_info: An array of up to 3 values meant to help edit parents that
+            A tuple with two elements
+
+            -   new_aps: A list of the new Aperture objects.
+
+            -   parent_edit_info: An array of up to 3 values meant to help edit parents that
                 have had their child faces triangulated. The 3 values are as follows:
-                    0 = The name of the original Aperture that was triangulated.
-                    1 = The name of the parent Face of the original Aperture
-                        (if it exists).
-                    2 = The name of the parent Room of the parent Face of the
-                        original Aperture (if it exists).
+
+                * 0 = The name of the original Aperture that was triangulated.
+                * 1 = The name of the parent Face of the original Aperture
+                  (if it exists).
+                * 2 = The name of the parent Room of the parent Face of the
+                  original Aperture (if it exists).
         """
         # make the new Apertures and add them to the model
         new_aps = []
@@ -894,7 +910,7 @@ class Model(_Base):
             if original_ap.has_parent:
                 new_ap._parent = original_ap.parent
             new_aps.append(new_ap)
-        
+
         # transfer over any child shades to the first triangulated object
         if len(original_ap._indoor_shades) != 0:
             new_shds = [shd.duplicate() for shd in original_ap._indoor_shades]
@@ -924,14 +940,18 @@ class Model(_Base):
                 to generate the new Door objects.
 
         Returns:
-            new_drs: A list of the new Door objects.
-            parent_edit_info: An array of up to 3 values meant to help edit parents that
+            A tuple with four elements
+
+            -   new_drs: A list of the new Door objects.
+
+            -   parent_edit_info: An array of up to 3 values meant to help edit parents that
                 have had their child faces triangulated. The 3 values are as follows:
-                    0 = The name of the original Door that was triangulated.
-                    1 = The name of the parent Face of the original Door
-                        (if it exists).
-                    2 = The name of the parent Room of the parent Face of the
-                        original Door (if it exists).
+
+                * 0 = The name of the original Door that was triangulated.
+                * 1 = The name of the parent Face of the original Door
+                  (if it exists).
+                * 2 = The name of the parent Room of the parent Face of the
+                  original Door (if it exists).
         """
         # make the new doors and add them to the model
         new_drs = []
@@ -1050,13 +1070,14 @@ class Model(_Base):
                         [dr.to_dict(True, included_prop) for dr in tri_drs])
 
         return base
-    
+
     @staticmethod
     def conversion_factor_to_meters(units):
         """Get the conversion factor to meters based on input units.
 
         Args:
             units: Text for the units. Choose from the following:
+
                 * Meters
                 * Millimeters
                 * Feet

--- a/honeybee/orientation.py
+++ b/honeybee/orientation.py
@@ -30,7 +30,7 @@ from ladybug_geometry.geometry2d.pointvector import Vector2D
 
 def angles_from_num_orient(num_subdivisions=4):
     """Get a list of angles based on the number of compass subdividsions.
-    
+
     Args:
         num_subdivisions: An integer for the number of times that the compass
             should be subdivided. Default: 4, which will yield angles for North,
@@ -51,14 +51,14 @@ def angles_from_num_orient(num_subdivisions=4):
 
 def face_orient_index(face, angles, north_vector=Vector2D(0, 1)):
     """Get the index to be used for a given face/aperture orientation from an angle list.
-    
+
     Args:
         face: A honeybee Face or Aperture object.
         angles: A list of angles that denote the boundaries of each orientation
             category.
         north_vector: An optional ladybug_geometry Vector2D for the north direction.
             Default is the Y-axis (0, 1).
-    
+
     Returns:
         An integer for the index used to assign properties to the object of the
         input orientation. Will be None if the input Face or Aperture is perfectly
@@ -72,13 +72,13 @@ def face_orient_index(face, angles, north_vector=Vector2D(0, 1)):
 
 def orient_index(orientation, angles):
     """Get the index to be used for a given face/aperture orientation from an angle list.
-    
+
     Args:
         orientation: The horizontal cardinal orientaion of the Face or Aperture
             in degrees.
         angles: A list of angles that denote the boundaries of each orientation
             category.
-    
+
     Returns:
         An integer for the index used to assign properties to the object of the
         input orientation.
@@ -91,7 +91,7 @@ def orient_index(orientation, angles):
 
 def inputs_by_index(orientation_index, all_inputs):
     """Get all of the inputs of a certain index from a list of all_inputs.
-    
+
     This is useful for getting the set of all inputs that should be assigned to
     a given Face or Aperture using its orientation_index.
     """
@@ -100,7 +100,7 @@ def inputs_by_index(orientation_index, all_inputs):
 
 def check_matching_inputs(all_inputs, num_orient=None):
     """Check that all orientation-specific inputs are coordinated.
-    
+
     This means that each input is either a array of values to be aplied to each
     orientation, which is has the same length as other orientation-specific arrays,
     or it is a single value to be used for all orientations.
@@ -111,10 +111,13 @@ def check_matching_inputs(all_inputs, num_orient=None):
         num_orient: An optional integer for the number of orientation categories
             to be used. If None, the length of the longest input list in the
             all_inputs will be used.
-    
+
     Returns:
-        all_inputs -- The input all_inputs with all sub-arrays having the same length.
-        num_orient -- An integer for the number of orientations used in the check.
+        A tuple with two elements
+
+        -   all_inputs -- The input all_inputs with all sub-arrays having the same length.
+
+        -   num_orient -- An integer for the number of orientations used in the check.
     """
     num_orient = max([len(inp) for inp in all_inputs]) if num_orient is None \
             else num_orient

--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -8,16 +8,16 @@ on their own but should have a host object.
 
 
 class _Properties(object):
-    """Base class for all Properties classes."""
+    """Base class for all Properties classes.
+
+    Args:
+        host: A honeybee-core geometry object that hosts these properties
+            (ie. Model, Room, Face, Shade, Aperture, Door).
+    """
     _do_not_duplicate = ('host', 'to_dict', 'ToString')
 
     def __init__(self, host):
-        """Initialize properties.
-
-        Args:
-            host: A honeybee-core geometry object that hosts these properties
-                (ie. Model, Room, Face, Shade, Aperture, Door).
-        """
+        """Initialize properties."""
         self._host = host
 
     @property
@@ -51,14 +51,14 @@ class _Properties(object):
                 import traceback
                 traceback.print_exc()
                 raise Exception('Failed to duplicate {}: {}'.format(var, e))
-    
+
     def _add_prefix_extension_attr(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated rooms).
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the object and does not add the prefix to attributes that are
         shared across several objects.
@@ -81,7 +81,7 @@ class _Properties(object):
                 import traceback
                 traceback.print_exc()
                 raise Exception('Failed to add prefix to {}: {}'.format(var, e))
-    
+
     def _reset_extension_attr_to_default(self):
         """Reset all extension attributes for the object to be default.
 
@@ -285,10 +285,10 @@ class RoomProperties(_Properties):
 
         base = self._add_extension_attr_to_dict(base, abridged, include)
         return base
-    
+
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Room (eg. single-room HVAC systems) and does not add the
         prefix to attributes that are shared across several Rooms (eg. ConstructionSets).
@@ -343,7 +343,7 @@ class FaceProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Face and does not add the prefix to attributes that are
         shared across several Faces.
@@ -352,7 +352,7 @@ class FaceProperties(_Properties):
             prefix: Text that will be inserted at the start of extension attribute names.
         """
         self._add_prefix_extension_attr(prefix)
-    
+
     def reset_to_default(self):
         """Reset the extension properties assigned at the level of this Face to default.
 
@@ -399,7 +399,7 @@ class ShadeProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Shade and does not add the prefix to attributes that are
         shared across several Shades.
@@ -455,7 +455,7 @@ class ApertureProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Aperture and does not add the prefix to attributes that are
         shared across several Apertures.
@@ -511,7 +511,7 @@ class DoorProperties(_Properties):
 
     def add_prefix(self, prefix):
         """Change the name extension attributes unique to this object by adding a prefix.
-        
+
         Notably, this method only adds the prefix to extension attributes that must
         be unique to the Door and does not add the prefix to attributes that are
         shared across several Doors.

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -19,6 +19,20 @@ import math
 class Room(_BaseWithShade):
     """A volume enclosed by faces, representing a single room or space.
 
+    Args:
+        name: Room name. Must be < 100 characters.
+        faces: A list or tuple of honeybee Face objects that together form the
+            closed volume of a room.
+        tolerance: The maximum difference between x, y, and z values
+            at which vertices of adjacent faces are considered equivalent. This is
+            used in determining whether the faces form a closed volume. Default
+            is 0, which makes no attempt to evaluate whether the Room volume
+            is closed.
+        angle_tolerance: The max angle difference in degrees that vertices are
+            allowed to differ from one another in order to consider them colinear.
+            Default is 0, which makes no attempt to evaluate whether the Room
+            volume is closed.
+
     Properties:
         * name
         * display_name
@@ -47,20 +61,6 @@ class Room(_BaseWithShade):
         facing outward from the room volume.  As such, an input tolerance of 0
         is intended for workflows where the solidity of the room volume has been
         evaluated elsewhere.
-
-        Args:
-            name: Room name. Must be < 100 characters.
-            faces: A list or tuple of honeybee Face objects that together form the
-                closed volume of a room.
-            tolerance: The maximum difference between x, y, and z values
-                at which vertices of adjacent faces are considered equivalent. This is
-                used in determining whether the faces form a closed volume. Default
-                is 0, which makes no attempt to evaluate whether the Room volume
-                is closed.
-            angle_tolerance: The max angle difference in degrees that vertices are
-                allowed to differ from one another in order to consider them colinear.
-                Default is 0, which makes no attempt to evaluate whether the Room
-                volume is closed.
         """
         _BaseWithShade.__init__(self, name)  # process the name
 
@@ -329,10 +329,10 @@ class Room(_BaseWithShade):
                 orientations += face.horizontal_orientation(north_vector) * face.area
                 areas += face.area
         return orientations / areas if areas != 0 else None
-    
+
     def add_prefix(self, prefix):
         """Change the name of this object and all child objects by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated rooms) since all objects
@@ -591,17 +591,19 @@ class Room(_BaseWithShade):
                 suitable for objects in meters.
 
         Returns:
-            dict: A dictionary of adjacency information with the following keys.
+            A dictionary of adjacency information with the following keys.
 
-                * adjacent_faces - A list of tuples with each tuple containing 2 objects
-                    for Faces paired in the process of solving adjacency. This data can
-                    be used to assign custom properties to the new adjacent Faces (like
-                    making all adjacencies an AirBoundary face type or assigning custom
-                    materials/construcitons).
-                * adjacent_apertures - A list of tuples with each tuple containing 2
-                    objects for Apertures paired in the process of solving adjacency.
-                * adjacent_doors - A list of tuples with each tuple containing 2 objects
-                    for Doors paired in the process of solving adjacency.
+            -   adjacent_faces - A list of tuples with each tuple containing 2 objects
+                for Faces paired in the process of solving adjacency. This data can
+                be used to assign custom properties to the new adjacent Faces (like
+                making all adjacencies an AirBoundary face type or assigning custom
+                materials/construcitons).
+
+            -   adjacent_apertures - A list of tuples with each tuple containing 2
+                objects for Apertures paired in the process of solving adjacency.
+
+            -   adjacent_doors - A list of tuples with each tuple containing 2 objects
+                for Doors paired in the process of solving adjacency.
         """
         # lists of adjacencies to track
         adj_info = {'adjacent_faces': [], 'adjacent_apertures': [],

--- a/honeybee/search.py
+++ b/honeybee/search.py
@@ -2,11 +2,11 @@
 
 This is useful for cases like the following:
 
-    * Searching through the honeybee-radiance modifier library.
-    * Searching through the honeybee-energy material, construction, schedule,
-        constructionset, or programtype libraries.
-    * Searching through EnergyPlus IDD or RDD to find possilbe output variables
-        to request form the simulation.
+* Searching through the honeybee-radiance modifier library.
+* Searching through the honeybee-energy material, construction, schedule,
+  constructionset, or programtype libraries.
+* Searching through EnergyPlus IDD or RDD to find possilbe output variables
+  to request form the simulation.
 """
 
 

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -13,6 +13,10 @@ import math
 class Shade(_Base):
     """A single planar shade.
 
+    Args:
+        name: Shade name. Must be < 100 characters.
+        geometry: A ladybug-geometry Face3D.
+
     Properties:
         * name
         * display_name
@@ -30,12 +34,7 @@ class Shade(_Base):
     __slots__ = ('_geometry', '_parent', '_is_indoor')
 
     def __init__(self, name, geometry):
-        """A single planar shade.
-
-        Args:
-            name: Shade name. Must be < 100 characters.
-            geometry: A ladybug-geometry Face3D.
-        """
+        """A single planar shade."""
         _Base.__init__(self, name)  # process the name
 
         # process the geometry
@@ -85,7 +84,7 @@ class Shade(_Base):
     @property
     def parent(self):
         """Get the parent object if assigned. None if not assigned.
-        
+
         The parent object can be either a Room, Face, Aperture or Door.
         """
         return self._parent
@@ -94,11 +93,11 @@ class Shade(_Base):
     def has_parent(self):
         """Get a boolean noting whether this Shade has a parent object."""
         return self._parent is not None
-    
+
     @property
     def is_indoor(self):
         """Get a boolean for whether this Shade is on the indoors of its parent object.
-        
+
         Note that, if there is no parent assigned to this Shade, this property will
         be False.
         """
@@ -146,10 +145,10 @@ class Shade(_Base):
     def perimeter(self):
         """Get the perimeter of the shade."""
         return self._geometry.perimeter
-    
+
     def add_prefix(self, prefix):
         """Change the name of this object by inserting a prefix.
-        
+
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object
         into one Model (like making a model of repeated rooms) since all objects


### PR DESCRIPTION
Hi @chriswmackey 

This time I found these error messages when I generated the pages.  

honeybee - ERROR - Failed to import honeybee_energy!
Traceback (most recent call last):
  File "C:\Users\sgara\Documents\GitHub\honeybee-core\honeybee\__init__.py", line 16, in <module>
    extensions[name] = importlib.import_module(name)
  File "c:\python27\lib\importlib\__init__.py", line 37, in import_module
    __import__(name)
  File "c:\python27\lib\site-packages\honeybee_energy\__init__.py", line 8, in <module>
    import honeybee_energy._extend_honeybee
  File "c:\python27\lib\site-packages\honeybee_energy\_extend_honeybee.py", line 19, in <module>
    from .properties.model import ModelEnergyProperties
  File "c:\python27\lib\site-packages\honeybee_energy\properties\model.py", line 5, in <module>
    from ..lib.constructionsets import generic_construction_set
  File "c:\python27\lib\site-packages\honeybee_energy\lib\constructionsets.py", line 2, in <module>
    from honeybee_energy.constructionset import ConstructionSet
  File "c:\python27\lib\site-packages\honeybee_energy\constructionset.py", line 5, in <module>
    from .material.opaque import EnergyMaterial, EnergyMaterialNoMass
  File "c:\python27\lib\site-packages\honeybee_energy\material\opaque.py", line 10, in <module>
    from ..writer import generate_idf_string
  File "c:\python27\lib\site-packages\honeybee_energy\writer.py", line 8, in <module>
    from honeybee.facetype import RoofCeiling, AirWall
ImportError: cannot import name AirWall

I believe I installed all the dependencies specified there in the repo and everything seems to be okay when I navigated the pages. Is this something to ignore?