### PR TITLE
feat(config): Organize default simulation folder

### DIFF
--- a/honeybee/config.py
+++ b/honeybee/config.py
@@ -121,7 +121,7 @@ class Folders(object):
         An attempt will be made to create the directory if it does not already exist.
         """
         home_folder = os.getenv('HOME') or os.path.expanduser('~')
-        sim_folder = os.path.join(home_folder, 'honeybee')
+        sim_folder = os.path.join(home_folder, 'honeybee', 'simulation')
         if not os.path.isdir(sim_folder):
             try:
                 os.makedirs(sim_folder)


### PR DESCRIPTION
I think it will help to add a little more hierarchy to the HOME/honeybee/ folder now that I see we want to keep the default standards data there. So I'm changing the default simulation folder to be HOME/honeybee/simulation/