### PR TITLE
feat(transform): Ensure extension properties are transformed with host

### DIFF
--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -222,7 +222,7 @@ class _BaseWithShade(_Base):
         return True
 
     def _add_shades_to_dict(self, base, abridged=False, included_prop=None):
-        """Method used to add child shades to the paret base dictionary.
+        """Method used to add child shades to the parent base dictionary.
 
         Args:
             base: The base object dictionary to which the child shades will be added.
@@ -259,7 +259,7 @@ class _BaseWithShade(_Base):
                 ishd._is_indoor = True
 
     def _duplicate_child_shades(self, new_object):
-        """Add duplicated child shades to a duplcated new_object."""
+        """Add duplicated child shades to a duplicated new_object."""
         new_object._outdoor_shades = [oshd.duplicate() for oshd in self._outdoor_shades]
         new_object._indoor_shades = [ishd.duplicate() for ishd in self._indoor_shades]
         for oshd in new_object._outdoor_shades:

--- a/honeybee/_lockable.py
+++ b/honeybee/_lockable.py
@@ -63,7 +63,7 @@ def lockable(cls):
             object.__setattr__(self, key, value)
 
     def init_decorator(func):
-        """Initialize the locabke decorator for the class."""
+        """Initialize the lockable decorator for the class."""
 
         @wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -93,7 +93,7 @@ def lockable(cls):
                 break
         if not _all_good:
             raise AttributeError(
-                'When using the @locakble decorator on a class with __slots__, '
+                'When using the @lockable decorator on a class with __slots__, '
                 'a "_locked" variable must be specified within __slots__.')
 
     return cls

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -107,7 +107,7 @@ class Aperture(_BaseWithShade):
             boundary_condition: Boundary condition object (eg. Outdoors, Surface).
                 Default: Outdoors.
             is_operable: Boolean to note whether the Aperture can be opened for
-                natrual ventilation. Default: False
+                natural ventilation. Default: False
         """
         geometry = Face3D(tuple(Point3D(*v) for v in vertices))
         return cls(identifier, geometry, boundary_condition, is_operable)
@@ -503,6 +503,7 @@ class Aperture(_BaseWithShade):
         """
         self._geometry = self.geometry.move(moving_vec)
         self.move_shades(moving_vec)
+        self.properties.move(moving_vec)
 
     def rotate(self, axis, angle, origin):
         """Rotate this Aperture by a certain angle around an axis and origin.
@@ -515,6 +516,7 @@ class Aperture(_BaseWithShade):
         """
         self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
         self.rotate_shades(axis, angle, origin)
+        self.properties.rotate(axis, angle, origin)
 
     def rotate_xy(self, angle, origin):
         """Rotate this Aperture counterclockwise in the world XY plane by a certain angle.
@@ -526,6 +528,7 @@ class Aperture(_BaseWithShade):
         """
         self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
         self.rotate_xy_shades(angle, origin)
+        self.properties.rotate_xy(angle, origin)
 
     def reflect(self, plane):
         """Reflect this Aperture across a plane.
@@ -536,6 +539,7 @@ class Aperture(_BaseWithShade):
         """
         self._geometry = self.geometry.reflect(plane.n, plane.o)
         self.reflect_shades(plane)
+        self.properties.reflect(plane)
 
     def scale(self, factor, origin=None):
         """Scale this Aperture by a factor from an origin point.
@@ -547,13 +551,14 @@ class Aperture(_BaseWithShade):
         """
         self._geometry = self.geometry.scale(factor, origin)
         self.scale_shades(factor, origin)
+        self.properties.scale(factor, origin)
 
     def check_planar(self, tolerance=0.01, raise_exception=True):
         """Check whether all of the Aperture's vertices lie within the same plane.
 
         Args:
             tolerance: The minimum distance between a given vertex and a the
-                object's's plane at which the vertex is said to lie in the plane.
+                object's plane at which the vertex is said to lie in the plane.
                 Default: 0.01, suitable for objects in meters.
             raise_exception: Boolean to note whether an ValueError should be
                 raised if a vertex does not lie within the object's plane.
@@ -565,7 +570,7 @@ class Aperture(_BaseWithShade):
                 self.display_name, e))
 
     def check_self_intersecting(self, raise_exception=True):
-        """Check whether the edges of the Aperture intersect one another (like a bowtwie)
+        """Check whether the edges of the Aperture intersect one another (like a bowtie)
 
         Args:
             raise_exception: If True, a ValueError will be raised if the object
@@ -584,7 +589,7 @@ class Aperture(_BaseWithShade):
         Args:
             tolerance: The minimum acceptable area of the object. Default is 0.0001,
                 which is equal to 1 cm2 when model units are meters. This is just
-                above the smalest size that OpenStudio will accept.
+                above the smallest size that OpenStudio will accept.
             raise_exception: If True, a ValueError will be raised if the object
                 area is below the tolerance. Default: True.
         """
@@ -616,7 +621,7 @@ class Aperture(_BaseWithShade):
 
         Args:
             abridged: Boolean to note whether the extension properties of the
-                object (ie. materials, construcitons) should be included in detail
+                object (ie. materials, constructions) should be included in detail
                 (False) or just referenced by identifier (True). Default: False.
             included_prop: List of properties to filter keys that must be included in
                 output dictionary. For example ['energy'] will include 'energy' key if

--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -54,7 +54,7 @@ class Outdoors(_BoundaryCondition):
         wind_exposure: A boolean noting whether the boundary is exposed to wind.
             Default: True.
         view_factor: A number between 0 and 1 for the view factor to the ground.
-            This input can also be an Autocalculate object to sigify that the view
+            This input can also be an Autocalculate object to signify that the view
             factor automatically calculated.  Default: autocalculate.
     """
 
@@ -80,7 +80,7 @@ class Outdoors(_BoundaryCondition):
         """Initialize Outdoors BoundaryCondition from a dictionary.
 
         Args:
-            data: A dictionary representaion of the boundary condition.
+            data: A dictionary representation of the boundary condition.
         """
         assert data['type'] == 'Outdoors', 'Expected dictionary for Outdoors boundary ' \
             'condition. Got {}.'.format(data['type'])
@@ -133,7 +133,7 @@ class Outdoors(_BoundaryCondition):
 
 
 class Surface(_BoundaryCondition):
-    """Bondary condition when an object is adjacent to another object."""
+    """Boundary condition when an object is adjacent to another object."""
 
     __slots__ = ('_boundary_condition_objects',)
 
@@ -166,7 +166,7 @@ class Surface(_BoundaryCondition):
         """Initialize Surface BoundaryCondition from a dictionary.
 
         Args:
-            data: A dictionary representaion of the boundary condition.
+            data: A dictionary representation of the boundary condition.
             sub_face: Boolean to note whether this boundary condition is applied to a
                 sub-face (an Aperture or a Door) instead of a Face. Default: False.
         """
@@ -203,7 +203,7 @@ class Surface(_BoundaryCondition):
     def boundary_condition_objects(self):
         """Get a tuple of up to 3 object identifiers that are adjacent to this one.
 
-        The first object is always the one that is immediately adjacet and is of
+        The first object is always the one that is immediately adjacent and is of
         the same object type (Face, Aperture, Door).
         When this boundary condition is applied to a Face, the second object in the
         tuple will be the parent Room of the adjacent object.
@@ -234,7 +234,7 @@ class Ground(_BoundaryCondition):
     """Ground boundary condition.
     
     Args:
-        data: A dictionary representaion of the boundary condition.
+        data: A dictionary representation of the boundary condition.
     """
     __slots__ = ()
 
@@ -313,7 +313,7 @@ boundary_conditions = _BoundaryConditions()
 
 
 def get_bc_from_position(positions, ground_depth=0):
-    """Return a boundary condition based on the relationship to a gound plane.
+    """Return a boundary condition based on the relationship to a ground plane.
 
     Positions that are entirely at or below the ground_depth will get a Ground
     boundary condition. If there are any positions above the ground_depth, an

--- a/honeybee/cli/validate.py
+++ b/honeybee/cli/validate.py
@@ -37,7 +37,7 @@ def validate_model(model_json):
         model_json: Full path to a Model JSON file.
     """
     try:
-        # check that the file is thre
+        # check that the file is there
         assert os.path.isfile(model_json), 'No JSON file found at {}.'.format(model_json)
     
         # validate the Model JSON
@@ -49,7 +49,7 @@ def validate_model(model_json):
         parsed_model = Model.from_dict(data)
         parsed_model.check_missing_adjacencies(raise_exception=True)
         click.echo('Python re-serialization passed.')
-        click.echo('Congratulations! Yout Model JSON is valid!')
+        click.echo('Congratulations! Your Model JSON is valid!')
     except Exception as e:
         _logger.exception('Model validation failed.\n{}'.format(e))
         sys.exit(1)

--- a/honeybee/colorobj.py
+++ b/honeybee/colorobj.py
@@ -74,17 +74,17 @@ class _ColorObject(object):
 
     @property
     def attributes(self):
-        """Get a tuple of text for the attributes assinged to the objects.
+        """Get a tuple of text for the attributes assigned to the objects.
 
         If the input attr_name is a valid attribute for the object but None is
-        assinged, the output will be 'None'. If the input attr_name is not valid
+        assigned, the output will be 'None'. If the input attr_name is not valid
         for the input object, 'N/A' will be returned.
         """
         return self._attributes
 
     @property
     def attributes_unique(self):
-        """Get a tuple of text for the unique attributes assinged to the objects."""
+        """Get a tuple of text for the unique attributes assigned to the objects."""
         return self._attributes_unique
 
     @property

--- a/honeybee/dictutil.py
+++ b/honeybee/dictutil.py
@@ -15,7 +15,7 @@ import honeybee.boundarycondition as hbc
 
 
 def dict_to_object(honeybee_dict, raise_exception=True):
-    """Re-serialize a dicationary of almost any object within honeybee.
+    """Re-serialize a dictionary of almost any object within honeybee.
 
     This includes any Model, Room, Face, Aperture, Door, Shade, or boundary
     condition object.
@@ -51,4 +51,4 @@ def dict_to_object(honeybee_dict, raise_exception=True):
         bc_class = getattr(hbc, obj_type)
         return bc_class.from_dict(honeybee_dict)
     elif raise_exception:
-        raise ValueError('{} is not a reconized honeybee object'.format(obj_type))
+        raise ValueError('{} is not a recognized honeybee object'.format(obj_type))

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -327,6 +327,7 @@ class Door(_BaseWithShade):
         """
         self._geometry = self.geometry.move(moving_vec)
         self.move_shades(moving_vec)
+        self.properties.move(moving_vec)
 
     def rotate(self, axis, angle, origin):
         """Rotate this Door by a certain angle around an axis and origin.
@@ -339,6 +340,7 @@ class Door(_BaseWithShade):
         """
         self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
         self.rotate_shades(axis, angle, origin)
+        self.properties.rotate(axis, angle, origin)
 
     def rotate_xy(self, angle, origin):
         """Rotate this Door counterclockwise in the world XY plane by a certain angle.
@@ -350,6 +352,7 @@ class Door(_BaseWithShade):
         """
         self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
         self.rotate_xy_shades(angle, origin)
+        self.properties.rotate_xy(angle, origin)
 
     def reflect(self, plane):
         """Reflect this Door across a plane.
@@ -360,6 +363,7 @@ class Door(_BaseWithShade):
         """
         self._geometry = self.geometry.reflect(plane.n, plane.o)
         self.reflect_shades(plane)
+        self.properties.reflect(plane)
 
     def scale(self, factor, origin=None):
         """Scale this Door by a factor from an origin point.
@@ -371,13 +375,14 @@ class Door(_BaseWithShade):
         """
         self._geometry = self.geometry.scale(factor, origin)
         self.scale_shades(factor, origin)
+        self.properties.scale(factor, origin)
 
     def check_planar(self, tolerance=0.01, raise_exception=True):
         """Check whether all of the Door's vertices lie within the same plane.
 
         Args:
             tolerance: The minimum distance between a given vertex and a the
-                object's's plane at which the vertex is said to lie in the plane.
+                object's plane at which the vertex is said to lie in the plane.
                 Default: 0.01, suitable for objects in meters.
             raise_exception: Boolean to note whether an ValueError should be
                 raised if a vertex does not lie within the object's plane.
@@ -389,7 +394,7 @@ class Door(_BaseWithShade):
                 self.display_name, e))
 
     def check_self_intersecting(self, raise_exception=True):
-        """Check whether the edges of the Door intersect one another (like a bowtwie).
+        """Check whether the edges of the Door intersect one another (like a bowtie).
 
         Args:
             raise_exception: If True, a ValueError will be raised if the object
@@ -408,7 +413,7 @@ class Door(_BaseWithShade):
         Args:
             tolerance: The minimum acceptable area of the object. Default is 0.0001,
                 which is equal to 1 cm2 when model units are meters. This is just
-                above the smalest size that OpenStudio will accept.
+                above the smallest size that OpenStudio will accept.
             raise_exception: If True, a ValueError will be raised if the object
                 area is below the tolerance. Default: True.
         """
@@ -440,7 +445,7 @@ class Door(_BaseWithShade):
 
         Args:
             abridged: Boolean to note whether the extension properties of the
-                object (ie. materials, construcitons) should be included in detail
+                object (ie. materials, constructions) should be included in detail
                 (False) or just referenced by identifier (True). Default: False.
             included_prop: List of properties to filter keys that must be included in
                 output dictionary. For example ['energy'] will include 'energy' key if

--- a/honeybee/extensionutil.py
+++ b/honeybee/extensionutil.py
@@ -36,7 +36,7 @@ def model_extension_dicts(data, extension_key, room_ext_dicts, face_ext_dicts,
         'Expected Model dictionary. Got {}.'.format(data['type'])
 
     # loop through the model dictionary using the same logic that the
-    # model does when you requst rooms, faces, shades, apertures and doors.
+    # model does when you request rooms, faces, shades, apertures and doors.
     if 'rooms' in data and data['rooms'] is not None:
         room_extension_dicts(data['rooms'], extension_key, room_ext_dicts,
                              face_ext_dicts, shade_ext_dicts, aperture_ext_dicts,

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -104,7 +104,7 @@ class Face(_BaseWithShade):
             bc_class = getattr(hbc, data['boundary_condition']['type'])
         except AttributeError:
             raise ValueError(
-                'Boundary condition "{}" is not supported in this honyebee '
+                'Boundary condition "{}" is not supported in this honeybee '
                 'installation.'.format(data['boundary_condition']['type']))
         bc = bc_class.from_dict(data['boundary_condition'])
         face = cls(data['identifier'], Face3D.from_dict(data['geometry']), face_type, bc)
@@ -150,7 +150,7 @@ class Face(_BaseWithShade):
     def type(self):
         """Get or set an object for Type of Face (ie. Wall, Floor, Roof).
 
-        Note that setting this property will reset extension attrributes on this
+        Note that setting this property will reset extension attributes on this
         Face to their default values.
         """
         return self._type
@@ -422,7 +422,7 @@ class Face(_BaseWithShade):
         Args:
             other_face: Another Face object to be set adjacent to this one.
             tolerance: The minimum distance between the center of two aperture
-                geometries at which they are condsidered adjacent. Default: 0.01,
+                geometries at which they are considered adjacent. Default: 0.01,
                 suitable for objects in meters.
 
         Returns:
@@ -627,7 +627,7 @@ class Face(_BaseWithShade):
         """Add a single rectangular aperture to the center of this Face.
 
         A rectangular window with the input width and height will always be added
-        by this method regardless of whether this parent Face contains a recongizable
+        by this method regardless of whether this parent Face contains a recognizable
         rectangular portion or not. Furthermore, this method preserves any existing
         apertures on the Face.
 
@@ -643,7 +643,7 @@ class Face(_BaseWithShade):
             sill_height: A number for the sill height. Default: 1.
             aperture_identifier: Optional string for the aperture identifier. If None, the default
                 will follow the convention "[face_identifier]_Glz[count]" where [count]
-                is one more than the current numer of apertures in the face.
+                is one more than the current number of apertures in the face.
 
         Returns:
             The new Aperture object that has been generated.
@@ -819,6 +819,7 @@ class Face(_BaseWithShade):
         for dr in self._doors:
             dr.move(moving_vec)
         self.move_shades(moving_vec)
+        self.properties.move(moving_vec)
         self._punched_geometry = None  # reset so that it can be re-computed
 
     def rotate(self, axis, angle, origin):
@@ -836,6 +837,7 @@ class Face(_BaseWithShade):
         for dr in self._doors:
             dr.rotate(axis, angle, origin)
         self.rotate_shades(axis, angle, origin)
+        self.properties.rotate(axis, angle, origin)
         self._punched_geometry = None  # reset so that it can be re-computed
 
     def rotate_xy(self, angle, origin):
@@ -852,6 +854,7 @@ class Face(_BaseWithShade):
         for dr in self._doors:
             dr.rotate_xy(angle, origin)
         self.rotate_xy_shades(angle, origin)
+        self.properties.rotate_xy(angle, origin)
         self._punched_geometry = None  # reset so that it can be re-computed
 
     def reflect(self, plane):
@@ -867,6 +870,7 @@ class Face(_BaseWithShade):
         for dr in self._doors:
             dr.reflect(plane)
         self.reflect_shades(plane)
+        self.properties.reflect(plane)
         self._punched_geometry = None  # reset so that it can be re-computed
 
     def scale(self, factor, origin=None):
@@ -883,6 +887,7 @@ class Face(_BaseWithShade):
         for dr in self._doors:
             dr.scale(factor, origin)
         self.scale_shades(factor, origin)
+        self.properties.scale(factor, origin)
         self._punched_geometry = None  # reset so that it can be re-computed
 
     def check_sub_faces_valid(self, tolerance=0.01, angle_tolerance=1, raise_exception=True):
@@ -962,7 +967,7 @@ class Face(_BaseWithShade):
 
         Args:
             tolerance: The minimum distance between a given vertex and a the
-                object's's plane at which the vertex is said to lie in the plane.
+                object's plane at which the vertex is said to lie in the plane.
                 Default: 0.01, suitable for objects in meters.
             raise_exception: Boolean to note whether an ValueError should be
                 raised if a vertex does not lie within the object's plane.
@@ -974,7 +979,7 @@ class Face(_BaseWithShade):
                 self.display_name, e))
 
     def check_self_intersecting(self, raise_exception=True):
-        """Check whether the edges of the Face intersect one another (like a bowtwie).
+        """Check whether the edges of the Face intersect one another (like a bowtie).
 
         Args:
             raise_exception: If True, a ValueError will be raised if the object
@@ -993,7 +998,7 @@ class Face(_BaseWithShade):
         Args:
             tolerance: The minimum acceptable area of the object. Default is 0.0001,
                 which is equal to 1 cm2 when model units are meters. This is just
-                above the smalest size that OpenStudio will accept.
+                above the smallest size that OpenStudio will accept.
             raise_exception: If True, a ValueError will be raised if the object
                 area is below the tolerance. Default: True.
         """
@@ -1025,7 +1030,7 @@ class Face(_BaseWithShade):
 
         Args:
             abridged: Boolean to note whether the extension properties of the
-                object (ie. materials, construcitons) should be included in detail
+                object (ie. materials, constructions) should be included in detail
                 (False) or just referenced by identifier (True). Default: False.
             included_prop: List of properties to filter keys that must be included in
                 output dictionary. For example ['energy'] will include 'energy' key if
@@ -1054,7 +1059,7 @@ class Face(_BaseWithShade):
         return base
 
     def _acceptable_sub_face_check(self, sub_face_type=Aperture):
-        """Check whether the Face can accept sub-faces and raise an excption if not."""
+        """Check whether the Face can accept sub-faces and raise an exception if not."""
         assert isinstance(self.boundary_condition, Outdoors), \
             '{} can only be added to Faces with a Outdoor boundary condition.'.format(
                 sub_face_type.__name__)

--- a/honeybee/orientation.py
+++ b/honeybee/orientation.py
@@ -1,4 +1,4 @@
-"""Collection of utilites for assigning different properties based on orientation.
+"""Collection of utilities for assigning different properties based on orientation.
 
 The functions here are meant to be adaptable to splitting up the compass based on
 however many bins the user desires, though the most common arrangement is likely
@@ -16,7 +16,7 @@ Usage:
     all_inputs = [ep_constructions, rad_materials]
     all_inputs, num_orient = check_matching_inputs(all_inputs)
 
-    # assign proeprties based on orientation
+    # assign properties based on orientation
     angles = angles_from_num_orient(num_orient)
     for face in hb_faces:
         orient_i = face_orient_index(face, angles)
@@ -74,7 +74,7 @@ def orient_index(orientation, angles):
     """Get the index to be used for a given face/aperture orientation from an angle list.
 
     Args:
-        orientation: The horizontal cardinal orientaion of the Face or Aperture
+        orientation: The horizontal cardinal orientation of the Face or Aperture
             in degrees.
         angles: A list of angles that denote the boundaries of each orientation
             category.
@@ -101,7 +101,7 @@ def inputs_by_index(orientation_index, all_inputs):
 def check_matching_inputs(all_inputs, num_orient=None):
     """Check that all orientation-specific inputs are coordinated.
 
-    This means that each input is either a array of values to be aplied to each
+    This means that each input is either a array of values to be applied to each
     orientation, which is has the same length as other orientation-specific arrays,
     or it is a single value to be used for all orientations.
 

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -209,7 +209,7 @@ class Room(_BaseWithShade):
         Multipliers are used to speed up the calculation when similar Rooms are
         repeated more than once. Essentially, a given simulation with the
         Room is run once and then the result is mutliplied by the multiplier.
-        This means that the "repetition" isn't in a particualr direction (it's
+        This means that the "repetition" isn't in a particular direction (it's
         essentially in the exact same location) and this comes with some
         inaccuracy. However, this error might not be too large if the Rooms
         are similar enough and it can often be worth it since it can greatly
@@ -421,6 +421,7 @@ class Room(_BaseWithShade):
         for face in self._faces:
             face.move(moving_vec)
         self.move_shades(moving_vec)
+        self.properties.move(moving_vec)
         if self._geometry is not None:
             self._geometry = self.geometry.move(moving_vec)
 
@@ -436,6 +437,7 @@ class Room(_BaseWithShade):
         for face in self._faces:
             face.rotate(axis, angle, origin)
         self.rotate_shades(axis, angle, origin)
+        self.properties.rotate(axis, angle, origin)
         if self._geometry is not None:
             self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
 
@@ -450,6 +452,7 @@ class Room(_BaseWithShade):
         for face in self._faces:
             face.rotate_xy(angle, origin)
         self.rotate_xy_shades(angle, origin)
+        self.properties.rotate_xy(angle, origin)
         if self._geometry is not None:
             self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
 
@@ -463,6 +466,7 @@ class Room(_BaseWithShade):
         for face in self._faces:
             face.reflect(plane)
         self.reflect_shades(plane)
+        self.properties.reflect(plane)
         if self._geometry is not None:
             self._geometry = self.geometry.reflect(plane.n, plane.o)
 
@@ -477,6 +481,7 @@ class Room(_BaseWithShade):
         for face in self._faces:
             face.scale(factor, origin)
         self.scale_shades(factor, origin)
+        self.properties.scale(factor, origin)
         if self._geometry is not None:
             self._geometry = self.geometry.scale(factor, origin)
 
@@ -517,7 +522,7 @@ class Room(_BaseWithShade):
 
         Args:
             tolerance: The minimum distance between a given vertex and a the
-                object's's plane at which the vertex is said to lie in the plane.
+                object's plane at which the vertex is said to lie in the plane.
                 Default: 0.01, suitable for objects in meters.
             raise_exception: Boolean to note whether an ValueError should be
                 raised if a vertex does not lie within the object's plane.
@@ -569,7 +574,7 @@ class Room(_BaseWithShade):
         Args:
             tolerance: The minimum acceptable area of the object. Default is 0.0001,
                 which is equal to 1 cm2 when model units are meters. This is just
-                above the smalest size that OpenStudio will accept.
+                above the smallest size that OpenStudio will accept.
             raise_exception: If True, a ValueError will be raised if the object
                 area is below the tolerance. Default: True.
         """
@@ -605,7 +610,7 @@ class Room(_BaseWithShade):
                 for Faces paired in the process of solving adjacency. This data can
                 be used to assign custom properties to the new adjacent Faces (like
                 making all adjacencies an AirBoundary face type or assigning custom
-                materials/construcitons).
+                materials/constructions).
 
             -   adjacent_apertures - A list of tuples with each tuple containing 2
                 objects for Apertures paired in the process of solving adjacency.
@@ -660,7 +665,7 @@ class Room(_BaseWithShade):
 
         Args:
             abridged: Boolean to note whether the extension properties of the
-                object (ie. construciton sets) should be included in detail
+                object (ie. construction sets) should be included in detail
                 (False) or just referenced by identifier (True). Default: False.
             included_prop: List of properties to filter keys that must be included in
                 output dictionary. For example ['energy'] will include 'energy' key if

--- a/honeybee/search.py
+++ b/honeybee/search.py
@@ -6,7 +6,7 @@ This is useful for cases like the following:
 * Searching through the honeybee-radiance modifier library.
 * Searching through the honeybee-energy material, construction, schedule,
   constructionset, or programtype libraries.
-* Searching through EnergyPlus IDD or RDD to find possilbe output variables
+* Searching through EnergyPlus IDD or RDD to find possible output variables
   to request form the simulation.
 """
 
@@ -22,9 +22,9 @@ def filter_array_by_keywords(array, keywords, parse_phrases=True):
             the given keywords.
         keywords: An array of strings representing keywords.
         parse_phrases: If True, this method will automatically parse any strings of
-            multiple keywords (spearated by spaces) into separate keywords for
-            searching. This results in a greater liklihood that someone finds what
-            they are searching for in large arrays but it may not be appropropriate for
+            multiple keywords (separated by spaces) into separate keywords for
+            searching. This results in a greater likelihood that someone finds what
+            they are searching for in large arrays but it may not be appropriate for
             all cases. You may want to set it to False when you are searching for a
             specific phrase that includes spaces. Default: True.
     """
@@ -65,8 +65,8 @@ def get_attr_nested(obj_instance, attr_name, decimal_count=None):
             number of decimal places if it is a float.
 
     Returns:
-        A string or number for tha attribute assinged ot the obj_instance. If the
-        input attr_name is a valid attribute for the object but None is assinged,
+        A string or number for tha attribute assigned ot the obj_instance. If the
+        input attr_name is a valid attribute for the object but None is assigned,
         the output will be 'None'. If the input attr_name is not valid for
         the input object, 'N/A' will be returned.
     """

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -177,6 +177,7 @@ class Shade(_Base):
                 to move the face.
         """
         self._geometry = self.geometry.move(moving_vec)
+        self.properties.move(moving_vec)
 
     def rotate(self, axis, angle, origin):
         """Rotate this Shade by a certain angle around an axis and origin.
@@ -188,6 +189,7 @@ class Shade(_Base):
                 object will be rotated.
         """
         self._geometry = self.geometry.rotate(axis, math.radians(angle), origin)
+        self.properties.rotate(axis, angle, origin)
 
     def rotate_xy(self, angle, origin):
         """Rotate this Shade counterclockwise in the world XY plane by a certain angle.
@@ -198,6 +200,7 @@ class Shade(_Base):
                 object will be rotated.
         """
         self._geometry = self.geometry.rotate_xy(math.radians(angle), origin)
+        self.properties.rotate_xy(angle, origin)
 
     def reflect(self, plane):
         """Reflect this Shade across a plane.
@@ -207,6 +210,7 @@ class Shade(_Base):
                 be reflected.
         """
         self._geometry = self.geometry.reflect(plane.n, plane.o)
+        self.properties.reflect(plane)
 
     def scale(self, factor, origin=None):
         """Scale this Shade by a factor from an origin point.
@@ -217,13 +221,14 @@ class Shade(_Base):
                 to scale. If None, it will be scaled from the World origin (0, 0, 0).
         """
         self._geometry = self.geometry.scale(factor, origin)
+        self.properties.scale(factor, origin)
 
     def check_planar(self, tolerance=0.01, raise_exception=True):
         """Check whether all of the Shade's vertices lie within the same plane.
 
         Args:
             tolerance: The minimum distance between a given vertex and a the
-                object's's plane at which the vertex is said to lie in the plane.
+                object's plane at which the vertex is said to lie in the plane.
                 Default: 0.01, suitable for objects in meters.
             raise_exception: Boolean to note whether an ValueError should be
                 raised if a vertex does not lie within the object's plane.
@@ -235,7 +240,7 @@ class Shade(_Base):
                 self.display_name, e))
 
     def check_self_intersecting(self, raise_exception=True):
-        """Check whether the edges of the Shade intersect one another (like a bowtwie).
+        """Check whether the edges of the Shade intersect one another (like a bowtie).
 
         Args:
             raise_exception: If True, a ValueError will be raised if the object
@@ -254,7 +259,7 @@ class Shade(_Base):
         Args:
             tolerance: The minimum acceptable area of the object. Default is 0.0001,
                 which is equal to 1 cm2 when model units are meters. This is just
-                above the smalest size that OpenStudio will accept.
+                above the smallest size that OpenStudio will accept.
             raise_exception: If True, a ValueError will be raised if the object
                 area is below the tolerance. Default: True.
         """

--- a/honeybee/typing.py
+++ b/honeybee/typing.py
@@ -139,7 +139,7 @@ def list_with_length(value, length=3, item_type=float, input_name=''):
 def clean_string(value, input_name=''):
     """Clean a string so that it is valid for both Radiance and EnergyPlus.
 
-    This will strip out spaces and special charcters and raise an error if the
+    This will strip out spaces and special characters and raise an error if the
     string is empty after stripping or has more than 100 characters.
     """
     try:
@@ -194,7 +194,7 @@ def clean_ep_string(value, input_name=''):
 def clean_and_id_string(value, input_name=''):
     """Clean a string and add 8 unique characters to it to make it unique.
 
-    Strings longer than 50 characters will be trucated before adding the ID.
+    Strings longer than 50 characters will be truncated before adding the ID.
     The resulting string will be valid for both Radiance and EnergyPlus.
     """
     try:
@@ -224,7 +224,7 @@ def clean_and_id_ep_string(value, input_name=''):
     """Clean a string and add 8 unique characters to it to make it unique for EnergyPlus.
 
     This includes stripping out all illegal charactersand removing trailing white spaces.
-    Strings longer than 50 characters will be trucated before adding the ID.
+    Strings longer than 50 characters will be truncated before adding the ID.
     """
     try:
         val = ''.join(i for i in value if ord(i) < 128)  # strip out non-ascii

--- a/honeybee/writer/__init__.py
+++ b/honeybee/writer/__init__.py
@@ -3,5 +3,5 @@
 Note to developers:
 Use this package to extend honeybee's geometry writers for new extensions.
 Functions added to the respective module of a given geometry object
-will show up under ther `to` method of the given object.
+will show up under the `to` method of the given object.
 """


### PR DESCRIPTION
This commit adds methods that allow extension attributes that are geometric to be transformed whenever their host is transformed.  These methods work by searching through the extension attributes and, if they find an extension that has the given transform method implemented (eg, move, rotate, scale), it will perform that transform whenever the host is transformed.

This is a necessary precursor to adding attributes to honeybee-radiance that include geometry (like dynamic shades that can be applied to specific radiance states). So, now, if someone moves a Room, the dynamic shades in the radiance properties of the Room's apertures are also moved.

@mostapharoudsari will also be very happy to see that the spell-checker is being put to good use.