### PR TITLE
feat(model): Add indoor_shades and outdoor_shades to Model

### DIFF
--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -335,6 +335,57 @@ class Model(_Base):
         return child_shades + self._orphaned_shades
 
     @property
+    def indoor_shades(self):
+        """Get a list of all indoor Shade objects in the model."""
+        child_shades = []
+        for room in self._rooms:
+            child_shades.extend(room._indoor_shades)
+            for face in room.faces:
+                child_shades.extend(face._indoor_shades)
+                for ap in face._apertures:
+                    child_shades.extend(ap._indoor_shades)
+                for dr in face._doors:
+                    child_shades.extend(dr._indoor_shades)
+        for face in self._orphaned_faces:
+            child_shades.extend(face._indoor_shades)
+            for ap in face._apertures:
+                child_shades.extend(ap._indoor_shades)
+            for dr in face._doors:
+                child_shades.extend(dr._indoor_shades)
+        for ap in self._orphaned_apertures:
+            child_shades.extend(ap._indoor_shades)
+        for dr in self._orphaned_doors:
+            child_shades.extend(dr._indoor_shades)
+        return child_shades
+
+    @property
+    def outdoor_shades(self):
+        """Get a list of all outdoor Shade objects in the model.
+
+        This includes all of the orphaned_shades.
+        """
+        child_shades = []
+        for room in self._rooms:
+            child_shades.extend(room._outdoor_shades)
+            for face in room.faces:
+                child_shades.extend(face._outdoor_shades)
+                for ap in face._apertures:
+                    child_shades.extend(ap._outdoor_shades)
+                for dr in face._doors:
+                    child_shades.extend(dr._outdoor_shades)
+        for face in self._orphaned_faces:
+            child_shades.extend(face._outdoor_shades)
+            for ap in face._apertures:
+                child_shades.extend(ap._outdoor_shades)
+            for dr in face._doors:
+                child_shades.extend(dr._outdoor_shades)
+        for ap in self._orphaned_apertures:
+            child_shades.extend(ap._outdoor_shades)
+        for dr in self._orphaned_doors:
+            child_shades.extend(dr._outdoor_shades)
+        return child_shades + self._orphaned_shades
+
+    @property
     def orphaned_faces(self):
         """Get a list of all Face objects without parent Rooms in the model."""
         return tuple(self._orphaned_faces)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'cli': ['click==7.1.1', "honeybee-schema==1.26.0;python_version>='3.6'"]
+        'cli': ['click==7.1.1', "honeybee-schema==1.23.0;python_version>='3.6'"]
     },
     entry_points={
         "console_scripts": ["honeybee = honeybee.cli:main"]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'cli': ['click==7.1.1', "honeybee-schema==1.23.0;python_version>='3.6'"]
+        'cli': ['click==7.1.1', "honeybee-schema==1.26.0;python_version>='3.6'"]
     },
     entry_points={
         "console_scripts": ["honeybee = honeybee.cli:main"]

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -49,12 +49,14 @@ def test_model_init():
     assert isinstance(model.rooms[0], Room)
     assert len(model.faces) == 6
     assert isinstance(model.faces[0], Face)
-    assert len(model.shades) == 2
-    assert isinstance(model.shades[0], Shade)
     assert len(model.apertures) == 2
     assert isinstance(model.apertures[0], Aperture)
     assert len(model.doors) == 1
     assert isinstance(model.doors[0], Door)
+    assert len(model.indoor_shades) == 1
+    assert isinstance(model.indoor_shades[0], Shade)
+    assert len(model.outdoor_shades) == 1
+    assert isinstance(model.outdoor_shades[0], Shade)
     assert len(model.orphaned_faces) == 0
     assert len(model.orphaned_shades) == 0
     assert len(model.orphaned_apertures) == 0

--- a/tests/shade_test.py
+++ b/tests/shade_test.py
@@ -257,14 +257,14 @@ def test_to_dict():
     vertices = [[0, 0, 0], [0, 10, 0], [0, 10, 3], [0, 0, 3]]
     shd = Shade.from_vertices('RectangleShade', vertices)
 
-    shdd = shd.to_dict()
-    assert shdd['type'] == 'Shade'
-    assert shdd['identifier'] == 'RectangleShade'
-    assert shdd['display_name'] == 'RectangleShade'
-    assert 'geometry' in shdd
-    assert len(shdd['geometry']['boundary']) == len(vertices)
-    assert 'properties' in shdd
-    assert shdd['properties']['type'] == 'ShadeProperties'
+    shd = shd.to_dict()
+    assert shd['type'] == 'Shade'
+    assert shd['identifier'] == 'RectangleShade'
+    assert shd['display_name'] == 'RectangleShade'
+    assert 'geometry' in shd
+    assert len(shd['geometry']['boundary']) == len(vertices)
+    assert 'properties' in shd
+    assert shd['properties']['type'] == 'ShadeProperties'
 
 
 def test_to_from_dict():


### PR DESCRIPTION
This will be particularly useful in honeybee-radiance workflows where we need to distinguish between indoor and outdoor shades in the Model radiance folder.