### PR TITLE
fix(properties): Allow null values when extensions are not used

### DIFF
--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -335,7 +335,7 @@ class ModelProperties(_Properties):
             data: A dictionary representation of an entire honeybee-core Model.
         """
         for atr in self._extension_attributes:
-            if atr not in data['properties']:
+            if atr not in data['properties'] or data['properties'][atr] is None:
                 continue
             var = getattr(self, atr)
             if var and not hasattr(var, 'apply_properties_from_dict'):


### PR DESCRIPTION
This effectively means that supplying `None` for an extension key is the same as not including the key at all.  I will send similar PRs to honeybee-schema, dragonfly-core, and dragonfly-schema.