### PR TITLE
fix(pypi): Update dependency to reference ladybug-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-lbt-ladybug==0.24.7
+ladybug-core==0.25.0


### PR DESCRIPTION
Since we are planning to turn lbt-ladybug into a package that installs ladybug along with all of its extensions.