### PR TITLE
fix(face): Fix sub-face normal correction upon re-serialization

### DIFF
--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -75,6 +75,7 @@ class Aperture(_BaseWithShade):
         assert data['type'] == 'Aperture', 'Expected Aperture dictionary. ' \
             'Got {}.'.format(data['type'])
 
+        # serialize the aperture
         is_operable = data['is_operable'] if 'is_operable' in data else False
         if data['boundary_condition']['type'] == 'Outdoors':
             boundary_condition = Outdoors.from_dict(data['boundary_condition'])
@@ -92,6 +93,7 @@ class Aperture(_BaseWithShade):
             aperture.user_data = data['user_data']
         aperture._recover_shades_from_dict(data)
 
+        # assign extension properties
         if data['properties']['type'] == 'ApertureProperties':
             aperture.properties._load_extension_attr_from_dict(data['properties'])
         return aperture

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -75,6 +75,7 @@ class Door(_BaseWithShade):
         assert data['type'] == 'Door', 'Expected Door dictionary. ' \
             'Got {}.'.format(data['type'])
 
+        # serialize the door
         is_glass = data['is_glass'] if 'is_glass' in data else False
         if data['boundary_condition']['type'] == 'Outdoors':
             boundary_condition = Outdoors.from_dict(data['boundary_condition'])
@@ -92,6 +93,7 @@ class Door(_BaseWithShade):
             door.user_data = data['user_data']
         door._recover_shades_from_dict(data)
 
+        # assign extension properties
         if data['properties']['type'] == 'DoorProperties':
             door.properties._load_extension_attr_from_dict(data['properties'])
         return door


### PR DESCRIPTION
The way the Face.from_dict() method was originally written, the checks to ensure that child faces have the same normal as their parent face were not occurring.

This makes sure that this check happens and it still does the check to make sure that Ground or Adiabatic BCs aren't assigned to Faces with Apertures or Doors.