### PR TITLE
fix(room): Implement better default for floor_height with no floors

### DIFF
--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -320,8 +320,8 @@ class Room(_BaseWithShade):
     def average_floor_height(self):
         """Get the height of the room floor averaged over all floor faces in the room.
 
-        Will be None if the room posseses no floors. Resulting value is weighted by
-        the area of each of the floor faces.
+        The resulting value is weighted by the area of each of the floor faces.
+        Will be the minimum Z value of the Room volume if the room posseses no floors.
         """
         heights = 0
         areas = 0
@@ -329,7 +329,7 @@ class Room(_BaseWithShade):
             if isinstance(face.type, Floor):
                 heights += face.center.z * face.area
                 areas += face.area
-        return heights / areas if areas != 0 else None
+        return heights / areas if areas != 0 else self.geometry.min.z
 
     @property
     def has_parent(self):


### PR DESCRIPTION
I realized that the fact that the average_floor_height returns None when there are no floors makes it very difficult to group Rooms by floor height to auto-generate stories.

So this commit changes this property to return the Room min Z when there are no floors.