### PR TITLE
fix(room): Flip sub-faces as part of orientation checks

### DIFF
--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 """Honeybee Aperture."""
+from __future__ import division
+
 from ._basewithshade import _BaseWithShade
 from .typing import clean_string
 from .properties import ApertureProperties

--- a/honeybee/door.py
+++ b/honeybee/door.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 """Honeybee Door."""
+from __future__ import division
+
 from ._basewithshade import _BaseWithShade
 from .typing import clean_string
 from .properties import DoorProperties

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 """Honeybee Face."""
+from __future__ import division
+
 from ._basewithshade import _BaseWithShade
 from .typing import clean_string
 from .properties import FaceProperties
@@ -47,6 +49,7 @@ class Face(_BaseWithShade):
         * outdoor_shades
         * parent
         * has_parent
+        * has_sub_faces
         * geometry
         * punched_geometry
         * vertices
@@ -199,6 +202,11 @@ class Face(_BaseWithShade):
     def has_parent(self):
         """Get a boolean noting whether this Face has a parent Room."""
         return self._parent is not None
+
+    @property
+    def has_sub_faces(self):
+        """Get a boolean noting whether this Face has Apertures or Doors."""
+        return not (self._apertures == [] and self._doors == [])
 
     @property
     def geometry(self):

--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 """Honeybee Model."""
+from __future__ import division
+
 from ._base import _Base
 from .properties import ModelProperties
 from .room import Room

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 """Honeybee Room."""
+from __future__ import division
+
 from ._basewithshade import _BaseWithShade
 from .typing import float_in_range, int_in_range, valid_string, clean_string
 from .properties import RoomProperties
@@ -89,7 +91,15 @@ class Room(_BaseWithShade):
             # replace honeybee face geometry with versions that are facing outwards
             if room_polyface.is_solid:
                 for i, correct_face3d in enumerate(room_polyface.faces):
-                    faces[i]._geometry = correct_face3d
+                    face = faces[i]
+                    norm_init = face._geometry.normal
+                    face._geometry = correct_face3d
+                    if face.has_sub_faces:  # flip sub-faces to align with parent Face
+                        if norm_init.angle(face._geometry.normal) > (math.pi / 2):
+                            for ap in face._apertures:
+                                ap._geometry = ap._geometry.flip()
+                            for dr in face._doors:
+                                dr._geometry = dr._geometry.flip()
             self._faces = faces
             self._geometry = room_polyface
 

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 """Honeybee Shade."""
+from __future__ import division
+
 from ._base import _Base
 from .typing import clean_string
 from .properties import ShadeProperties


### PR DESCRIPTION
The check that we have to flip the orientation of Faces to ensure they point outwards from a Room was not also performing a check for whether there were sub-faces that needed to be flipped.

This commit fixes this issue.