### PR TITLE
feat(cli): Add groups for creating and editing models

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 honeybee-schema==1.39.0;python_version>='3.7'
+ladybug-geometry-polyskel==1.3.11
 coverage==5.3
 coveralls==1.7.0;python_version<'3.0'
 coveralls==2.1.2;python_version>='3.6'

--- a/honeybee/cli/__init__.py
+++ b/honeybee/cli/__init__.py
@@ -67,6 +67,8 @@ import json
 
 from ..config import folders
 from honeybee.cli.validate import validate
+from honeybee.cli.create import create
+from honeybee.cli.edit import edit
 
 # TODO: Comment out and use for logging once we are adding commands to this file.
 # import logging
@@ -112,6 +114,8 @@ def viz():
 
 
 main.add_command(validate)
+main.add_command(create)
+main.add_command(edit)
 
 
 if __name__ == "__main__":

--- a/honeybee/cli/create.py
+++ b/honeybee/cli/create.py
@@ -1,0 +1,207 @@
+"""honeybee model creation commands."""
+
+try:
+    import click
+except ImportError:
+    raise ImportError(
+        'click is not installed. Try `pip install . [cli]` command.'
+    )
+
+from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
+from ladybug_geometry.geometry2d.polygon import Polygon2D
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.face import Face3D
+from ladybug_geometry.geometry3d.polyface import Polyface3D
+from ladybug_geometry_polyskel.polysplit import perimeter_core_subpolygons
+
+from honeybee.model import Model
+from honeybee.room import Room
+from honeybee.facetype import face_types as fts
+from honeybee.boundarycondition import boundary_conditions as bcs
+try:
+    ad_bc = bcs.adiabatic
+except AttributeError:  # honeybee_energy is not loaded and adiabatic does not exist
+    ad_bc = None
+
+import sys
+import os
+import logging
+import json
+import math
+import uuid
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group(help='Commands for creating Honeybee models.')
+def create():
+    pass
+
+
+@create.command('shoe-box')
+@click.argument('width', type=float)
+@click.argument('depth', type=float)
+@click.argument('height', type=float)
+@click.option('--orientation-angle', '-a', help='A number between 0 and 360 for the '
+              'clockwise orientation of the box in degrees. (0=North, 90=East, 180='
+              'South, 270=West).', type=float, default=0, show_default=True)
+@click.option('--window-ratio', '-wr', help='A number between 0 and 1 (but not equal to 1) '
+              'for the ratio between aperture area and area of the face pointing towards'
+              ' the orientation-angle.', type=float, default=0.4, show_default=True)
+@click.option('--adiabatic/--outdoors', ' /-o', help='Flag to note whether the faces that '
+              'are not in the direction of the orientation-angle are adiabatic or '
+              'outdoors.', default=True, show_default=True)
+@click.option('--units', '-u', help=' Text for the units system in which the model '
+              'geometry exists. Must be (Meters, Millimeters, Feet, Inches, Centimeters).',
+              type=str, default='Meters', show_default=True)
+@click.option('--tolerance', '-t', help='The maximum difference between x, y, and z '
+              'values at which vertices are considered equivalent.',
+              type=float, default=0.01, show_default=True)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON string.'
+              ' By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def shoe_box(width, depth, height, orientation_angle, window_ratio, adiabatic,
+             units, tolerance, output_file):
+    """Create a model with a single shoe box Room.
+    \n
+    Args:\n
+        width: Number for the width of the box (in the X direction).\n
+        depth: Number for the depth of the box (in the Y direction).\n
+        height: Number for the height of the box (in the Z direction).
+    """
+    try:
+        unique_id = str(uuid.uuid4())[:8]  # unique identifier for the shoe box
+
+        # create the box room and assign all of the attributes
+        room_id = 'Shoe_Box_Room_{}'.format(unique_id)
+        room = Room.from_box(room_id, width, depth, height, orientation_angle)
+        room.display_name = 'Shoe_Box_Room'
+        front_face = room[1]
+        front_face.apertures_by_ratio(window_ratio, tolerance)
+        if adiabatic and ad_bc:
+            room[0].boundary_condition = ad_bc  # make the floor adiabatic
+            for face in room[2:]:  # make all other face adiabatic
+                face.boundary_condition = ad_bc
+
+        # create the model object
+        model_id = 'Shoe_Box_Model_{}'.format(unique_id)
+        model = Model(model_id, [room], units=units,
+                      tolerance=tolerance, angle_tolerance=1)
+
+        # write the model out to the file or stdout
+        output_file.write(json.dumps(model.to_dict()))
+    except Exception as e:
+        _logger.exception('Shoe box creation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@create.command('rectangle-plan')
+@click.argument('width', type=float)
+@click.argument('length', type=float)
+@click.argument('floor-to-floor-height', type=float)
+@click.option('--perimeter-offset', '-p', help='An optional positive number that will be'
+              ' used  to offset the perimeter to create core/perimeter Rooms. '
+              'If this value is 0, no offset will occur and each floor will have one '
+              'Room', type=float, default=0, show_default=True)
+@click.option('--story-count', '-s', help='An integer for the number of stories to '
+              'generate.', type=int, default=1, show_default=True)
+@click.option('--orientation-angle', '-a', help='A number between 0 and 360 for the '
+              'clockwise orientation that the width of the box faces.(0=North, 90=East, '
+              '180=South, 270=West).', type=float, default=0, show_default=True)
+@click.option('--outdoor-roof/--adiabatic-roof', ' /-ar', help='Flag to note whether '
+              'the roof faces of the top floor should be outdoor or adiabatic.',
+              default=True, show_default=True)
+@click.option('--ground-floor/--adiabatic-floor', ' /-af', help='Flag to note whether '
+              'the floor faces of the bottom floor should be ground or adiabatic.',
+              default=True, show_default=True)
+@click.option('--units', '-u', help=' Text for the units system in which the model '
+              'geometry exists. Must be (Meters, Millimeters, Feet, Inches, Centimeters).',
+              type=str, default='Meters', show_default=True)
+@click.option('--tolerance', '-t', help='The maximum difference between x, y, and z '
+              'values at which vertices are considered equivalent.',
+              type=float, default=0.01, show_default=True)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON '
+              'string. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def rectangle_plan(width, length, floor_to_floor_height, perimeter_offset, story_count,
+                   orientation_angle, outdoor_roof, ground_floor, units, tolerance,
+                   output_file):
+    """Create a model with a rectangular floor plan.\n
+    Note that the resulting Rooms in the model won't have any windows or solved
+    adjacencies and the edit commands should be used for this purpose.\n
+    \n
+    Args:\n
+        width: Number for the width of the plan (in the X direction).\n
+        depth: Number for the depth of the plan (in the Y direction).\n
+        floor_to_floor_height: Number for the height of each floor of the model
+            (in the Z direction).
+    """
+    try:
+        unique_id = str(uuid.uuid4())[:8]  # unique identifier for the rooms
+
+        # create the geometry of the rooms for the first floor
+        footprint = Face3D.from_rectangle(width, length)
+        if perimeter_offset != 0:  # use the straight skeleton methods
+            assert perimeter_offset > 0, 'perimeter_offset cannot be less than than 0.'
+            try:
+                footprint = []
+                base = Polygon2D.from_rectangle(Point2D(), Vector2D(0, 1), width, length)
+                sub_polys_perim, sub_polys_core = perimeter_core_subpolygons(
+                    polygon=base, distance=perimeter_offset, tol=tolerance)
+                for s_poly in sub_polys_perim + sub_polys_core:
+                    sub_face = Face3D([Point3D(pt.x, pt.y, 0) for pt in s_poly])
+                    footprint.append(sub_face)
+            except RuntimeError as e:
+                footprint = [Face3D.from_rectangle(width, length)]
+        else:
+            footprint = [Face3D.from_rectangle(width, length)]
+        first_floor = [Polyface3D.from_offset_face(geo, floor_to_floor_height)
+                       for geo in footprint]
+
+        # rotate the geometries if an orientation angle is specified
+        if orientation_angle != 0:
+            angle, origin = math.radians(orientation_angle), Point3D()
+            first_floor = [geo.rotate_xy(angle, origin) for geo in first_floor]
+
+        # create the initial rooms for the first floor
+        rmids = ['Room'] if len(first_floor) == 1 else ['Front', 'Right', 'Back', 'Left']
+        if len(first_floor) == 5:
+            rmids.append('Core')
+        rooms = []
+        for polyface, rmid in zip(first_floor, rmids):
+            rooms.append(Room.from_polyface3d('{}_{}'.format(rmid, unique_id), polyface))
+
+        # if there are multiple stories, duplicate the first floor rooms
+        if story_count != 1:
+            all_rooms = []
+            for i in range(story_count):
+                for room in rooms:
+                    new_room = room.duplicate()
+                    new_room.add_prefix('Floor{}'.format(i + 1))
+                    m_vec = Vector3D(0, 0, floor_to_floor_height * i)
+                    new_room.move(m_vec)
+                    all_rooms.append(new_room)
+            rooms = all_rooms
+
+        # assign adiabatic boundary conditions if requested
+        if not outdoor_roof and ad_bc:
+            for room in rooms[-len(first_floor):]:
+                room[-1].boundary_condition = ad_bc  # make the roof adiabatic
+        if not ground_floor and ad_bc:
+            for room in rooms[:len(first_floor)]:
+                room[0].boundary_condition = ad_bc  # make the floor adiabatic
+
+        # create the model object
+        model_id = 'Rectangle_Plan_Model_{}'.format(unique_id)
+        model = Model(model_id, rooms, units=units,
+                      tolerance=tolerance, angle_tolerance=1)
+
+        # write the model out to the file or stdout
+        output_file.write(json.dumps(model.to_dict()))
+    except Exception as e:
+        _logger.exception('Rectangle plan model creation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/honeybee/cli/edit.py
+++ b/honeybee/cli/edit.py
@@ -1,0 +1,307 @@
+"""honeybee model editing commands."""
+
+try:
+    import click
+except ImportError:
+    raise ImportError(
+        'click is not installed. Try `pip install . [cli]` command.'
+    )
+
+from ladybug_geometry.geometry3d.pointvector import Vector3D
+
+from honeybee.model import Model
+from honeybee.room import Room
+from honeybee.facetype import face_types, Wall
+from honeybee.boundarycondition import Outdoors
+from honeybee.boundarycondition import boundary_conditions as bcs
+try:
+    ad_bc = bcs.adiabatic
+except AttributeError:  # honeybee_energy is not loaded and adiabatic does not exist
+    ad_bc = None
+
+
+import sys
+import os
+import logging
+import json
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group(help='Commands for editing Honeybee models.')
+def edit():
+    pass
+
+
+@edit.command('convert-units')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.argument('units', type=str)
+@click.option('--scale/--do-not-scale', ' /-ns', help='Flag to note whether the model '
+              'should be scaled as it is converted to the new units system.',
+              default=True, show_default=True)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON string'
+              ' with solved adjacency. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def convert_units(model_json, units, scale, output_file):
+    """Convert a Model to a given units system.
+    \n
+    Args:\n
+        model_json: Full path to a Model JSON file.\n
+        units: Text for the units system to which the model will be converted.
+            Choose from (Meters, Millimeters, Feet, Inches, Centimeters).
+    """
+    try:
+        # serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        parsed_model = Model.from_dict(data)
+
+        # convert the units of the model
+        if scale:
+            parsed_model.convert_to_units(units)
+        else:
+            parsed_model.units = units
+
+        # write the new model out to the file or stdout
+        output_file.write(json.dumps(parsed_model.to_dict()))
+    except Exception as e:
+        _logger.exception('Model unit conversion failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@edit.command('solve-adjacency')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.option('--wall/--air-boundary', ' /-ab', help='Flag to note whether the '
+              'wall adjacencies should be of the air boundary face type.',
+              default=True, show_default=True)
+@click.option('--surface/--adiabatic', ' /-a', help='Flag to note whether the '
+              'adjacencies should be surface or adiabatic.',
+              default=True, show_default=True)
+@click.option('--no-overwrite/--overwrite', ' /-ow', help='Flag to note whether existing'
+              ' Surface boundary conditions should be overwritten.',
+              default=True, show_default=True)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON string'
+              ' with solved adjacency. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def solve_adjacency(model_json, wall, surface, no_overwrite, output_file):
+    """Solve adjacency between Rooms of a Model JSON file.
+    \n
+    Args:\n
+        model_json: Full path to a Model JSON file.
+    """
+    try:
+        # serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        parsed_model = Model.from_dict(data)
+        # check the Model tolerance
+        assert parsed_model.tolerance != 0, \
+            'Model must have a non-zero tolerance to use solve-adjacency.'
+        tol = parsed_model.tolerance
+
+        # solve adjacency
+        if no_overwrite:  # only assign new adjacencies
+            adj_info = Room.solve_adjacency(parsed_model.rooms, tol)
+        else:  # overwrite existing Surface BC
+            adj_faces = Room.find_adjacency(parsed_model.rooms, tol)
+            for face_pair in adj_faces:
+                face_pair[0].set_adjacency(face_pair[1])
+            adj_info = {'adjacent_faces': adj_faces}
+
+        # try to assign the air boundary face type
+        if not wall:
+            for face_pair in adj_info['adjacent_faces']:
+                if isinstance(face_pair[0].type, Wall):
+                    face_pair[0].type = face_types.air_boundary
+                    face_pair[1].type = face_types.air_boundary
+
+        # try to assign the adiabatic boundary condition
+        if not surface and ad_bc:
+            for face_pair in adj_info['adjacent_faces']:
+                face_pair[0].boundary_condition = ad_bc
+                face_pair[1].boundary_condition = ad_bc
+
+        # write the new model out to the file or stdout
+        output_file.write(json.dumps(parsed_model.to_dict()))
+    except Exception as e:
+        _logger.exception('Model solve adjacency failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@edit.command('windows-by-ratio')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.argument('ratio', type=float)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON string'
+              ' with windows. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def windows_by_ratio(model_json, ratio, output_file):
+    """Add apertures to all outdoor walls of a model given a ratio.\n
+    Note that this method removes any existing apertures and doors from the Walls.\n
+    This method attempts to generate as few apertures as necessary to meet the ratio.\n
+    \n
+    Args:\n
+        model_json: Full path to a Model JSON file.\n
+        ratio: A number between 0 and 1 (but not perfectly equal to 1)
+            for the desired ratio between wall area and face area.
+    """
+    try:
+        # serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        parsed_model = Model.from_dict(data)
+        # check the Model tolerance
+        assert parsed_model.tolerance != 0, \
+            'Model must have a non-zero tolerance to use windows-by-ratio.'
+        tol = parsed_model.tolerance
+
+        # generate the windows for all walls of rooms
+        for room in parsed_model.rooms:
+            for face in room.faces:
+                if isinstance(face.boundary_condition, Outdoors) and \
+                        isinstance(face.type, Wall):
+                    face.apertures_by_ratio(ratio, tol)
+
+        # write the new model out to the file or stdout
+        output_file.write(json.dumps(parsed_model.to_dict()))
+    except Exception as e:
+        _logger.exception('Model windows by ratio failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@edit.command('windows-by-ratio-rect')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.argument('ratio', type=float)
+@click.argument('aperture-height', type=float)
+@click.argument('sill-height', type=float)
+@click.argument('horizontal-separation', type=float)
+@click.option('--vertical-separation', '-vs', help='An optional number to create a '
+              'single vertical separation between top and bottom apertures.',
+              type=float, default=0, show_default=True)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON string'
+              ' with windows. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def windows_by_ratio_rect(model_json, ratio, aperture_height, sill_height,
+                          horizontal_separation, vertical_separation, output_file):
+    """Add apertures to all outdoor walls of a model given a ratio.\n
+    Note that this method removes any existing apertures and doors from the Walls.\n
+    Any rectangular portions of walls will have customized rectangular apertures
+    using the various inputs.\n
+    \n
+    Args:\n
+        model_json: Full path to a Model JSON file.\n
+        ratio: A number between 0 and 1 (but not perfectly equal to 1)
+            for the desired ratio between wall area and face area.
+        aperture_height: A number for the target height of the output apertures.
+            Note that, if the ratio is too large for the height, the ratio will
+            take precedence and the actual aperture_height will be larger
+            than this value.
+        sill_height: A number for the target height above the bottom edge of
+            the rectangle to start the apertures. Note that, if the
+            ratio is too large for the height, the ratio will take precedence
+            and the sill_height will be smaller than this value.
+        horizontal_separation: A number for the target separation between
+            individual aperture centerlines.  If this number is larger than
+            the parent rectangle base, only one aperture will be produced.
+    """
+    try:
+        # serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        parsed_model = Model.from_dict(data)
+        # check the Model tolerance
+        assert parsed_model.tolerance != 0, \
+            'Model must have a non-zero tolerance to use windows-by-ratio-rect.'
+        tol = parsed_model.tolerance
+
+        # generate the windows for all walls of rooms
+        for room in parsed_model.rooms:
+            for face in room.faces:
+                if isinstance(face.boundary_condition, Outdoors) and \
+                        isinstance(face.type, Wall):
+                    face.apertures_by_ratio_rectangle(
+                        ratio, aperture_height, sill_height, horizontal_separation,
+                        vertical_separation, tol)
+
+        # write the new model out to the file or stdout
+        output_file.write(json.dumps(parsed_model.to_dict()))
+    except Exception as e:
+        _logger.exception('Model windows by ratio rect failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+@edit.command('overhang')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.argument('depth', type=float)
+@click.option('--angle', '-a', help='A number for the for an angle to rotate the '
+              'overhang in degrees. Positive numbers indicate a downward rotation while '
+              'negative numbers indicate an upward rotation.',
+              type=float, default=0, show_default=True)
+@click.option('--vertical-offset', '-vo', help='An optional number for the vertical '
+              'offset of the overhang from the top of the window or face. Positive '
+              'numbers move up while negative mode down.',
+              type=float, default=0, show_default=True)
+@click.option('--per-window/--per-wall', ' /-pw', help='Flag to note whether the '
+              'overhangs should be generated per aperture or per wall.',
+              default=True, show_default=True)
+@click.option('--outdoor/--indoor', ' /-i', help='Flag to note whether the overhangs '
+              'should be on the indoors like a light shelf.',
+              default=True, show_default=True)
+@click.option('--output-file', '-f', help='Optional file to output the Model JSON string'
+              ' with overhangs. By default it will be printed out to stdout',
+              type=click.File('w'), default='-')
+def overhang(model_json, depth, angle, vertical_offset, per_window, outdoor, output_file):
+    """Add overhangs to all outdoor walls or windows in walls.\n
+    \n
+    Args:\n
+        model_json: Full path to a Model JSON file.\n
+        depth: A number for the overhang depth.
+    """
+    try:
+        # serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        parsed_model = Model.from_dict(data)
+        # check the Model tolerance
+        assert parsed_model.tolerance != 0, \
+            'Model must have a non-zero tolerance to use overhang.'
+        tol = parsed_model.tolerance
+        indoor = not outdoor
+
+        # generate the overhangs for all walls of rooms
+        overhangs = []
+        for room in parsed_model.rooms:
+            for face in room.faces:
+                if isinstance(face.boundary_condition, Outdoors) and \
+                        isinstance(face.type, Wall):
+                    if per_window:
+                        for ap in face.apertures:
+                            overhangs.extend(ap.overhang(depth, angle, indoor, tol))
+                    else:
+                        overhangs.extend(face.overhang(depth, angle, indoor, tol))
+
+        # move the overhangs if an offset has been specified
+        if vertical_offset != 0:
+            m_vec = Vector3D(0, 0, vertical_offset)
+            for shd in overhangs:
+                shd.move(m_vec)
+
+        # write the new model out to the file or stdout
+        output_file.write(json.dumps(parsed_model.to_dict()))
+    except Exception as e:
+        _logger.exception('Model overhang failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/honeybee/cli/validate.py
+++ b/honeybee/cli/validate.py
@@ -30,7 +30,8 @@ def validate():
 
 
 @validate.command('model')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 def validate_model(model_json):
     """Validate all properties of a Model JSON file against the Honeybee schema.\b
     This includes basic properties like adjacency checks AND all geometry checks.
@@ -39,10 +40,8 @@ def validate_model(model_json):
         model_json: Full path to a Model JSON file.
     """
     try:
-        # check that the file is there
-        assert os.path.isfile(model_json), 'No JSON file found at {}.'.format(model_json)
-        click.echo('Validating Model JSON ...')
         # first check the JSON against the OpenAPI specification
+        click.echo('Validating Model JSON ...')
         schema_model.Model.parse_file(model_json)
         click.echo('Pydantic validation passed.')
         # re-serialize the Model to make sure no errors are found in re-serialization
@@ -84,7 +83,8 @@ def validate_model(model_json):
 
 
 @validate.command('model-basic')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 def validate_model_basic(model_json):
     """Validate basic properties of a Model JSON against the Honeybee schema.\b
     This includes basic re-serialization, unique identifier checks, and adjacency checks.
@@ -93,10 +93,8 @@ def validate_model_basic(model_json):
         model_json: Full path to a Model JSON file.
     """
     try:
-        # check that the file is there
-        assert os.path.isfile(model_json), 'No JSON file found at {}.'.format(model_json)
-        click.echo('Validating Model JSON ...')
         # first check the JSON against the OpenAPI specification
+        click.echo('Validating Model JSON ...')
         schema_model.Model.parse_file(model_json)
         click.echo('Pydantic validation passed.')
         # re-serialize the Model to make sure no errors are found in re-serialization
@@ -122,7 +120,8 @@ def validate_model_basic(model_json):
 
 
 @validate.command('model-geometry')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 def validate_model_geometry(model_json):
     """Validate geometry of a Model JSON against the Honeybee schema.\b
     This includes checks that the 5 honeybee geometry rules are upheld.
@@ -131,10 +130,8 @@ def validate_model_geometry(model_json):
         model_json: Full path to a Model JSON file.
     """
     try:
-        # check that the file is there
-        assert os.path.isfile(model_json), 'No JSON file found at {}.'.format(model_json)
-        click.echo('Validating Model JSON ...')
         # re-serialize the Model to make sure no errors are found in re-serialization
+        click.echo('Validating Model JSON ...')
         with open(model_json) as json_file:
             data = json.load(json_file)
         parsed_model = Model.from_dict(data)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setuptools.setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'cli': ['click==7.1.2', "honeybee-schema==1.39.0;python_version>='3.6'"]
+        'cli': ['click==7.1.2', "honeybee-schema==1.39.0;python_version>='3.6'",
+                'ladybug-geometry-polyskel==1.3.11']
     },
     entry_points={
         "console_scripts": ["honeybee = honeybee.cli:main"]

--- a/tests/cli_create_test.py
+++ b/tests/cli_create_test.py
@@ -1,0 +1,83 @@
+"""Test basic CLI commands that create Honeybee Models."""
+import sys
+import json
+from click.testing import CliRunner
+
+from honeybee.model import Model
+from honeybee.boundarycondition import Outdoors, Ground
+from honeybee.cli.create import shoe_box, rectangle_plan
+
+
+def test_shoe_box_simple():
+    runner = CliRunner()
+    result = runner.invoke(shoe_box, ['5', '10', '3.5'])
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert len(new_model.rooms) == 1
+    assert len(new_model.apertures) == 1
+
+
+def test_shoe_box_detailed():
+    runner = CliRunner()
+    in_arg = ['15', '30', '9', '-a', '180', '-wr', '0.6', '-o', '-u', 'Feet']
+    result = runner.invoke(shoe_box, in_arg)
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert new_model.units == 'Feet'
+    assert len(new_model.rooms) == 1
+    assert all(isinstance(face.boundary_condition, (Outdoors, Ground))
+               for face in new_model.faces)
+    assert len(new_model.apertures) == 1
+    assert new_model.apertures[0].cardinal_direction() == 'South'
+
+
+def test_rectangle_plan_simple():
+    runner = CliRunner()
+    result = runner.invoke(rectangle_plan, ['30', '20', '3.5'])
+    assert result.exit_code == 0
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert len(new_model.rooms) == 1
+    assert len(new_model.apertures) == 0
+
+    result = runner.invoke(rectangle_plan, ['30', '20', '3.5', '-p', '5'])
+    assert result.exit_code == 0
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert len(new_model.rooms) == 5
+
+    result = runner.invoke(rectangle_plan, ['30', '20', '3.5', '-p', '10'])
+    assert result.exit_code == 0
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert len(new_model.rooms) == 4
+
+
+def test_rectangle_plan_detailed():
+    runner = CliRunner()
+    in_arg = ['100', '50', '10', '-p', '15', '-s', '3', '-a', '45', '-u', 'Feet']
+    result = runner.invoke(rectangle_plan, in_arg)
+    assert result.exit_code == 0
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert new_model.units == 'Feet'
+    assert len(new_model.rooms) == 15
+    assert len(new_model.apertures) == 0
+    assert all(isinstance(face.boundary_condition, (Outdoors, Ground))
+               for face in new_model.faces)
+
+
+def test_rectangle_plan_detailed():
+    runner = CliRunner()
+    in_arg = ['30', '20', '3.5', '-p', '5', '-a', '135', '-ar', '-af']
+    result = runner.invoke(rectangle_plan, in_arg)
+    assert result.exit_code == 0
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert new_model.units == 'Meters'
+    assert len(new_model.rooms) == 5
+    assert len(new_model.apertures) == 0

--- a/tests/cli_edit_test.py
+++ b/tests/cli_edit_test.py
@@ -1,0 +1,73 @@
+"""Test basic CLI commands that create Honeybee Models."""
+import sys
+import json
+import pytest
+from click.testing import CliRunner
+
+from honeybee.model import Model
+from honeybee.facetype import AirBoundary
+from honeybee.cli.edit import convert_units, solve_adjacency, windows_by_ratio, \
+    windows_by_ratio_rect, overhang
+
+
+def test_convert_units():
+    input_model = './tests/json/single_family_home.hbjson'
+    runner = CliRunner()
+    result = runner.invoke(convert_units, [input_model, 'Feet'])
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert new_model.units == 'Feet'
+
+
+def test_solve_adjacency():
+    input_model = './tests/json/single_family_home.hbjson'
+    runner = CliRunner()
+    result = runner.invoke(solve_adjacency, [input_model, '-ab', '-ow'])
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    ab_count = 0
+    for face in new_model.faces:
+        if isinstance(face.type, AirBoundary):
+            ab_count += 1
+    assert ab_count > 10
+
+
+def test_windows_by_ratio():
+    input_model = './tests/json/single_family_home.hbjson'
+    runner = CliRunner()
+    result = runner.invoke(windows_by_ratio, [input_model, '0.6'])
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert new_model.exterior_aperture_area / new_model.exterior_wall_area == \
+        pytest.approx(0.6, rel=1e-3)
+
+
+def test_windows_by_ratio_rect():
+    input_model = './tests/json/single_family_home.hbjson'
+    runner = CliRunner()
+    in_args = [input_model, '0.3', '2.0', '0.8', '1.0']
+    result = runner.invoke(windows_by_ratio_rect, in_args)
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert new_model.exterior_aperture_area / new_model.exterior_wall_area == \
+        pytest.approx(0.3, rel=1e-3)
+
+
+def test_windows_by_ratio_rect():
+    input_model = './tests/json/single_family_home.hbjson'
+    runner = CliRunner()
+    in_args = [input_model, '0.4', '-a', '10', '-vo', '0.5', '-i']
+    result = runner.invoke(overhang, in_args)
+    assert result.exit_code == 0
+
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    assert all(len(ap.indoor_shades) == 1 for ap in new_model.apertures)

--- a/tests/cli_validate_test.py
+++ b/tests/cli_validate_test.py
@@ -1,11 +1,4 @@
-"""Test cli.
-
-honeybee-core currently doesn't have many commands but nevertheless it is good to have a
-sample code for reference. For more information see Click's documentation:
-
-http://click.palletsprojects.com/en/7.x/testing/
-
-"""
+"""Test basic CLI commands and the validate group"""
 import sys
 import json
 

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -543,6 +543,26 @@ def test_solve_adjacency_aperture():
     assert len(adj_info['adjacent_doors']) == 0
 
 
+def test_find_adjacency():
+    """Test the find adjacency method."""
+    room_south = Room.from_box('SouthZone', 5, 5, 3, origin=Point3D(0, 0, 0))
+    room_north = Room.from_box('NorthZone', 5, 5, 3, origin=Point3D(0, 5, 0))
+
+    assert room_south[1].boundary_condition == boundary_conditions.outdoors
+    assert room_north[3].boundary_condition == boundary_conditions.outdoors
+
+    adj_faces = Room.find_adjacency([room_south, room_north], 0.01)
+    assert len(adj_faces) == 1
+    assert len(adj_faces[0]) == 2
+
+    adj_info = Room.solve_adjacency([room_south, room_north], 0.01)
+
+    # make sure it all still works after the Surface BC is already set
+    adj_faces = Room.find_adjacency([room_south, room_north], 0.01)
+    assert len(adj_faces) == 1
+    assert len(adj_faces[0]) == 2
+
+
 def test_group_by_orientation():
     """Test the group_by_orientation method."""
     pts_1 = (Point3D(0, 0), Point3D(15, 0), Point3D(10, 5), Point3D(5, 5))


### PR DESCRIPTION
This commit adds two new groups for creating models  and editing their geometry.

The create group houses methods for creating model JSONs for typical geometry cases like shoe boxes, rectangles and (eventually), regular polygons, L and H-shaped plans, etc.

The edit group houses methods for solving adjacency, converting units, generating windows by ratio, generating overhangs.