### PR TITLE
feat(cli): Add more commands to generate different types of shades

### DIFF
--- a/honeybee/cli/create.py
+++ b/honeybee/cli/create.py
@@ -47,7 +47,8 @@ def create():
               'South, 270=West).', type=float, default=0, show_default=True)
 @click.option('--window-ratio', '-wr', help='A number between 0 and 1 (but not equal to 1) '
               'for the ratio between aperture area and area of the face pointing towards'
-              ' the orientation-angle.', type=float, default=0.4, show_default=True)
+              ' the orientation-angle. Using 0 will generate no windows',
+              type=float, default=0, show_default=True)
 @click.option('--adiabatic/--outdoors', ' /-o', help='Flag to note whether the faces that '
               'are not in the direction of the orientation-angle are adiabatic or '
               'outdoors.', default=True, show_default=True)

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -819,7 +819,8 @@ class Face(_BaseWithShade):
 
     def louvers_by_distance_between(
             self, distance, depth, offset=0, angle=0, contour_vector=Vector2D(0, 1),
-            flip_start_side=False, indoor=False, tolerance=0.01, base_name=None):
+            flip_start_side=False, indoor=False, tolerance=0.01, max_count=None,
+            base_name=None):
         """Add a series of louvered Shade objects over this Face.
 
         Args:
@@ -843,21 +844,33 @@ class Face(_BaseWithShade):
                 indoor geometry). Default: False.
             tolerance: An optional value to remove any louvers with a length less
                 than the tolerance. Default: 0.01, suitable for objects in meters.
-            base_name: Optional base identifier for the shade objects. If None, the default
-                is InShd or OutShd depending on whether indoor is True.
+            max_count: Optional integer to set the maximum number of louvers that
+                will be generated. If None, louvers will cover the entire face.
+            base_name: Optional base identifier for the shade objects. If None, the
+                default is InShd or OutShd depending on whether indoor is True.
 
         Returns:
             A list of the new Shade objects that have been generated.
         """
+        # set defaults
         angle = math.radians(angle)
-        louvers = []
         face_geo = self.geometry if indoor is False else self.geometry.flip()
         if base_name is None:
             shd_name_base = '{}_InShd{}' if indoor else '{}_OutShd{}'
         else:
             shd_name_base = '{}_' + str(base_name) + '{}'
+
+        # generate shade geometries
         shade_faces = face_geo.countour_fins_by_distance_between(
             distance, depth, offset, angle, contour_vector, flip_start_side, tolerance)
+        if max_count:
+            try:
+                shade_faces = shade_faces[:max_count]
+            except IndexError:  # fewer shades were generated than the max count
+                pass
+        
+        # create the shade objects
+        louvers = []
         for i, shade_geo in enumerate(shade_faces):
             louvers.append(Shade(shd_name_base.format(self.identifier, i), shade_geo))
         if indoor:

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -165,17 +165,41 @@ def test_aperture_extruded_border():
     assert all(shd.is_indoor for shd in aperture_2.indoor_shades)
 
 
+def test_aperture_louvers_by_count():
+    """Test the creation of a louvers_by_count for Face objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    aperture = Aperture('RectangleWindow', Face3D(pts_1))
+    aperture.louvers_by_count(3, 0.2, 0.1, 5)
+
+    assert len(aperture.outdoor_shades) == 3
+    for louver in aperture.outdoor_shades:
+        assert isinstance(louver, Shade)
+        assert louver.area == 5 * 0.2
+        assert louver.has_parent
+
+
 def test_aperture_louvers_by_distance_between():
     """Test the creation of a louvers_by_distance_between for Aperture objects."""
     pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
     aperture = Aperture('RectangleWindow', Face3D(pts_1))
     aperture.louvers_by_distance_between(0.5, 0.2, 0.1)
-
     assert len(aperture.outdoor_shades) == 6
     for louver in aperture.outdoor_shades:
         assert isinstance(louver, Shade)
         assert louver.area == 5 * 0.2
         assert louver.has_parent
+
+    aperture.remove_shades()
+    aperture.louvers_by_distance_between(0.5, 0.2, 0.1, max_count=3)
+    assert len(aperture.outdoor_shades) == 3
+    for louver in aperture.outdoor_shades:
+        assert isinstance(louver, Shade)
+        assert louver.area == 5 * 0.2
+        assert louver.has_parent
+
+    aperture.remove_shades()
+    aperture.louvers_by_distance_between(0.5, 0.2, 0.1, max_count=10)
+    assert len(aperture.outdoor_shades) == 6
 
 
 def test_move():

--- a/tests/cli_create_test.py
+++ b/tests/cli_create_test.py
@@ -16,7 +16,7 @@ def test_shoe_box_simple():
     model_dict = json.loads(result.output)
     new_model = Model.from_dict(model_dict)
     assert len(new_model.rooms) == 1
-    assert len(new_model.apertures) == 1
+    assert len(new_model.apertures) == 0
 
 
 def test_shoe_box_detailed():

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -434,17 +434,41 @@ def test_face_overhang():
     assert face_2.outdoor_shades[0].has_parent
 
 
+def test_face_louvers_by_count():
+    """Test the creation of a louvers_by_count for Face objects."""
+    pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
+    face = Face('RectangleFace', Face3D(pts_1))
+    face.louvers_by_count(3, 0.2, 0.1, 5)
+
+    assert len(face.outdoor_shades) == 3
+    for louver in face.outdoor_shades:
+        assert isinstance(louver, Shade)
+        assert louver.area == 5 * 0.2
+        assert louver.has_parent
+
+
 def test_face_louvers_by_distance_between():
     """Test the creation of a louvers_by_distance_between for Face objects."""
     pts_1 = (Point3D(0, 0, 0), Point3D(0, 0, 3), Point3D(5, 0, 3), Point3D(5, 0, 0))
     face = Face('RectangleFace', Face3D(pts_1))
     face.louvers_by_distance_between(0.5, 0.2, 0.1)
-
     assert len(face.outdoor_shades) == 6
     for louver in face.outdoor_shades:
         assert isinstance(louver, Shade)
         assert louver.area == 5 * 0.2
         assert louver.has_parent
+
+    face.remove_shades()
+    face.louvers_by_distance_between(0.5, 0.2, 0.1, max_count=3)
+    assert len(face.outdoor_shades) == 3
+    for louver in face.outdoor_shades:
+        assert isinstance(louver, Shade)
+        assert louver.area == 5 * 0.2
+        assert louver.has_parent
+
+    face.remove_shades()
+    face.louvers_by_distance_between(0.5, 0.2, 0.1, max_count=10)
+    assert len(face.outdoor_shades) == 6
 
 
 def test_move():


### PR DESCRIPTION
This commit adds commands to add extruded borders and various types of louvers.

I also added a max_count option to the louvers by distance methods, which I think a lot of people will appreciate in order to generate light-shelf-like louvers.

LAstly, I'm changing the default WWR for the shoe box to be 0 so that it can better integrate with the edit methods that assign specific window and shade geometries.