### PR TITLE
fix(dep): move ladybug-geometry-polyskel to requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 honeybee-schema==1.39.0;python_version>='3.7'
-ladybug-geometry-polyskel==1.3.11
 coverage==5.3
 coveralls==1.7.0;python_version<'3.0'
 coveralls==2.1.2;python_version>='3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ladybug-core==0.31.2
+ladybug-geometry-polyskel==1.3.11

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'cli': ['click==7.1.2', "honeybee-schema==1.39.0;python_version>='3.6'",
-                'ladybug-geometry-polyskel==1.3.11']
+        'cli': ['click==7.1.2', "honeybee-schema==1.39.0;python_version>='3.6'"]
     },
     entry_points={
         "console_scripts": ["honeybee = honeybee.cli:main"]


### PR DESCRIPTION
As it is set up right now ladybug-geometry-polyskel doesn't get installed with the requirements. As a result the test for honeybee-radiance and honeybee-energy cli fails. Add it to the main requirements fixes the issue.

https://travis-ci.org/github/ladybug-tools/honeybee-radiance/jobs/736251292#L1438

https://travis-ci.org/github/ladybug-tools/honeybee-energy/jobs/736142705#L6159 