### PR TITLE
fix(identifier): Allow identifier to be set by the user

### DIFF
--- a/honeybee/_base.py
+++ b/honeybee/_base.py
@@ -19,20 +19,24 @@ class _Base(object):
 
     def __init__(self, identifier):
         """Initialize base object."""
-        self._identifier = valid_string(identifier, 'honeybee object identifier')
+        self.identifier = identifier
         self._display_name = self._identifier
         self._properties = None
         self._user_data = None
 
     @property
     def identifier(self):
-        """Get a text string for the unique object identifer.
+        """Get or set a text string for the unique object identifer.
 
         This identifier remains constant as the object is mutated, copied, and
         serialized to different formats (eg. dict, idf, rad). As such, this
         property is used to reference the object across a Model.
         """
         return self._identifier
+
+    @identifier.setter
+    def identifier(self, value):
+        self._identifier = valid_string(value, 'honeybee object identifier')
 
     @property
     def display_name(self):


### PR DESCRIPTION
I originally had the property as read only in order to prevent the many cases where setting the identifier will break existing references across objects. But I think I have just come to realize that I can't stop people from playing with fire if they want to.  I guess people should be aware that re-setting a unique ID can have unintended consequences unless they know that they are doing.