### PR TITLE
fix(search): Change search behavior to get more specific with more terms

### DIFF
--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -48,11 +48,13 @@ class Model(_Base):
 
         tolerance: The maximum difference between x, y, and z values at which
             vertices are considered equivalent. Zero indicates that no tolerance
-            checks should be performed. Default: 0.
-        angle_tolerance: The max angle difference in degrees that vertices are
-            allowed to differ from one another in order to consider them colinear.
-            Zero indicates that no angle tolerance checks should be performed.
-            Default: 0.
+            checks should be performed. None indicates that the tolerance will be
+            set based on the units above, with the tolerance consistently being
+            between 1 cm and 1 mm (roughly the tolerance implicit in the OpenStudio
+            SDK). (Default: None).
+        angle_tolerance: The max angle difference in degrees that vertices are allowed
+            to differ from one another in order to consider them colinear. Zero indicates
+            that no angle tolerance checks should be performed. (Default: 1.0).
 
     Properties:
         * identifier
@@ -86,10 +88,12 @@ class Model(_Base):
                  '_orphaned_doors', '_units', '_tolerance', '_angle_tolerance')
 
     UNITS = ('Meters', 'Millimeters', 'Feet', 'Inches', 'Centimeters')
+    UNITS_TOLERANCES = {'Meters': 0.01, 'Millimeters': 1.0, 'Feet': 0.01,
+                        'Inches':0.1, 'Centimeters':1.0}
 
     def __init__(self, identifier, rooms=None, orphaned_faces=None, orphaned_shades=None,
                  orphaned_apertures=None, orphaned_doors=None,
-                 units='Meters', tolerance=0, angle_tolerance=0):
+                 units='Meters', tolerance=None, angle_tolerance=1.0):
         """A collection of Rooms, Faces, Apertures, and Doors for an entire model."""
         _Base.__init__(self, identifier)  # process the identifier
 
@@ -239,7 +243,8 @@ class Model(_Base):
 
     @tolerance.setter
     def tolerance(self, value):
-        self._tolerance = float_positive(value, 'model tolerance')
+        self._tolerance = float_positive(value, 'model tolerance') if value is not None \
+            else self.UNITS_TOLERANCES[self.units]
 
     @property
     def angle_tolerance(self):
@@ -1041,12 +1046,13 @@ class Model(_Base):
                 triangle Apertures meant to replace an Aperture with more than
                 4 sides in the model.
 
-            -   parents_to_edit: An list of lists that parellels the triangulated_apertures
-                in that each item represents an Aperture that has been triangulated
-                in the model. However, each of these lists holds between 1 and 3 values
-                for the identifiers of the original aperture and parents of the aperture.
-                This information is intended to help edit parent faces that have had
-                their child faces triangulated. The 3 values are as follows:
+            -   parents_to_edit: An list of lists that parellels the triangulated
+                aperturesin that each item represents an Aperture that has been
+                triangulated in the model. However, each of these lists holds between
+                1 and 3 values for the identifiers of the original aperture and parents
+                of the aperture. This information is intended to help edit parent
+                faces that have had their child faces triangulated. The 3 values
+                are as follows:
 
                 * 0 = The identifier of the original Aperture that was triangulated.
                 * 1 = The identifier of the parent Face of the original Aperture
@@ -1058,7 +1064,7 @@ class Model(_Base):
         parents_to_edit = []
         all_apertures = self.apertures
         adj_check = []  # confirms when interior apertures are triangulated by adjacency
-        for i, ap in enumerate(all_apertures):
+        for ap in all_apertures:
             if len(ap.geometry) <= 4:
                 pass
             elif ap.identifier not in adj_check:
@@ -1118,7 +1124,7 @@ class Model(_Base):
         parents_to_edit = []
         all_doors = self.doors
         adj_check = []  # confirms when interior doors are triangulated by adjacency
-        for i, dr in enumerate(all_doors):
+        for dr in all_doors:
             if len(dr.geometry) <= 4:
                 pass
             elif dr.identifier not in adj_check:
@@ -1164,8 +1170,9 @@ class Model(_Base):
 
             -   new_aps: A list of the new Aperture objects.
 
-            -   parent_edit_info: An array of up to 3 values meant to help edit parents that
-                have had their child faces triangulated. The 3 values are as follows:
+            -   parent_edit_info: An array of up to 3 values meant to help edit
+                parents that have had their child faces triangulated. The 3 values
+                are as follows:
 
                 * 0 = The identifier of the original Aperture that was triangulated.
                 * 1 = The identifier of the parent Face of the original Aperture
@@ -1216,8 +1223,9 @@ class Model(_Base):
 
             -   new_drs: A list of the new Door objects.
 
-            -   parent_edit_info: An array of up to 3 values meant to help edit parents that
-                have had their child faces triangulated. The 3 values are as follows:
+            -   parent_edit_info: An array of up to 3 values meant to help edit
+                parents that have had their child faces triangulated. The 3 values
+                are as follows:
 
                 * 0 = The identifier of the original Door that was triangulated.
                 * 1 = The identifier of the parent Face of the original Door

--- a/honeybee/search.py
+++ b/honeybee/search.py
@@ -46,10 +46,7 @@ def any_keywords_in_string(name, keywords):
         keywords: An array of strings representing keywords, which will be searched for
             in the name.
     """
-    for kw in keywords:
-        if kw in name:
-            return True
-    return False
+    return all(kw in name for kw in keywords)
 
 
 def get_attr_nested(obj_instance, attr_name, decimal_count=None):

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -40,8 +40,8 @@ def test_model_init():
     assert model.identifier == 'TinyHouse'
     assert model.display_name == 'TinyHouse'
     assert model.units == 'Meters'
-    assert model.tolerance == 0
-    assert model.angle_tolerance == 0
+    assert model.tolerance == 0.01
+    assert model.angle_tolerance == 1.0
     assert len(model.rooms) == 1
     assert isinstance(model.rooms[0], Room)
     assert len(model.faces) == 6
@@ -82,10 +82,12 @@ def test_model_properties_setability():
     assert model.display_name == 'TestBox'
     model.units = 'Feet'
     assert model.units == 'Feet'
-    model.tolerance = 0.01
-    assert model.tolerance == 0.01
+    model.tolerance = 0.1
+    assert model.tolerance == 0.1
     model.angle_tolerance = 0.01
     assert model.angle_tolerance == 0.01
+    model.tolerance = None
+    assert model.tolerance == 0.01
 
 
 def test_model_init_orphaned_objects():

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -13,7 +13,7 @@ def test_any_keywords_in_string():
 
     assert any_keywords_in_string(elements, keywords_1)
     assert any_keywords_in_string(elements, keywords_2)
-    assert any_keywords_in_string(elements, keywords_3)
+    assert not any_keywords_in_string(elements, keywords_3)
     assert not any_keywords_in_string(elements, keywords_4)
     assert not any_keywords_in_string(elements, keywords_5)
 
@@ -29,9 +29,9 @@ def test_filter_array_by_keywords():
     keywords_6 = ('Hydrogen', 'Helium')
 
     assert filter_array_by_keywords(elements, keywords_1) == ['Fire']
-    assert filter_array_by_keywords(elements, keywords_2) == ['Fire', 'Water']
-    assert filter_array_by_keywords(elements, keywords_3) == ['Water']
-    assert filter_array_by_keywords(elements, keywords_4) == ['Fire']
+    assert filter_array_by_keywords(elements, keywords_2) == []
+    assert filter_array_by_keywords(elements, keywords_3) == []
+    assert filter_array_by_keywords(elements, keywords_4) == []
     assert filter_array_by_keywords(elements, keywords_4, False) == []
     assert filter_array_by_keywords(elements, keywords_5) == []
     assert filter_array_by_keywords(elements, keywords_6) == []


### PR DESCRIPTION
It finally dawned on my why the search behavior wasn't working as I expected. Normally, more search terms should mean a narrower set of results. Now I only choose the boolean intersection of the search terms instead of the boolean union.