### PR TITLE
fix(ci): Loosen requirements in CI so that pip stops breaking things

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ladybug-core==0.37.0
-ladybug-geometry-polyskel==1.3.20
+ladybug-core==0.37.2
+ladybug-geometry-polyskel==1.3.21
 honeybee-schema==1.42.0;python_version>='3.7'


### PR DESCRIPTION
I am getting rid of the == operator in the dependency versions  just for the CI so that we don't always get the tests failing every time we make a change to ladybug-geomtery.