### PR TITLE
fix(config): Add try/except to catch potential race conditions

### DIFF
--- a/honeybee/config.py
+++ b/honeybee/config.py
@@ -240,9 +240,10 @@ class Folders(object):
         if not os.path.isdir(sim_folder):
             try:
                 os.makedirs(sim_folder)
-            except Exception as e:
-                raise OSError('Failed to create default simulation '
-                              'folder: %s\n%s' % (sim_folder, e))
+            except OSError as e:
+                if e.errno != 17:  # avoid race conditions between multiple tasks
+                    raise OSError('Failed to create default simulation '
+                                  'folder: %s\n%s' % (sim_folder, e))
         return sim_folder
 
     def _find_honeybee_schema_version(self):

--- a/honeybee/logutil.py
+++ b/honeybee/logutil.py
@@ -29,7 +29,11 @@ def _get_log_folder():
     home_folder = os.getenv('HOME') or os.path.expanduser('~')
     log_folder = os.path.join(home_folder, '.honeybee')
     if not os.path.isdir(log_folder):
-        os.mkdir(log_folder)
+        try:
+            os.mkdir(log_folder)
+        except OSError as e:
+            if e.errno != 17:  # avoid race conditions between multiple tasks
+                raise OSError('Failed to create log folder: %s\n%s' % (log_folder, e))
     return log_folder
 
 


### PR DESCRIPTION
It seems parallel luigi tasks can cause race conditions with certain operations like creating default simulation folders.  These try/excepts should catch these cases now.