### PR TITLE
style(room): Ensure faces_by_guide_surface works with concave faces

### DIFF
--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -588,7 +588,8 @@ class Room(_BaseWithShade):
                 for srf_geo in surface_geometry:
                     pl1, pl2 = face.geometry.plane, srf_geo.plane
                     if pl1.is_coplanar_tolerance(pl2, tolerance, ang_tol):
-                        if srf_geo.is_point_on_face(face.center, tolerance):
+                        pt_on_face = face.geometry._point_on_face(tolerance * 2)
+                        if srf_geo.is_point_on_face(pt_on_face, tolerance):
                             selected_faces.append(face)
                             break
         else:  # first check to see if the Face is on the correct side of the surface
@@ -601,7 +602,8 @@ class Room(_BaseWithShade):
                         break
                     pl1, pl2 = face.geometry.plane, srf_geo.plane
                     if pl1.is_coplanar_tolerance(pl2, tolerance, ang_tol):
-                        if srf_geo.is_point_on_face(face.center, tolerance):
+                        pt_on_face = face.geometry._point_on_face(tolerance * 2)
+                        if srf_geo.is_point_on_face(pt_on_face, tolerance):
                             selected_faces.append(face)
                             break
         return selected_faces


### PR DESCRIPTION
I realized that the method might not be so reliable for concave faces where the center point lies outside of the face boundary.

So I am changing it to use the exact ladybug_geometry method that gets called in the solve adjacency method, which ensure that we always get a point that is on the face.