### PR TITLE
fix(validate): Improve the self-intersection check

### DIFF
--- a/honeybee/_basewithshade.py
+++ b/honeybee/_basewithshade.py
@@ -202,20 +202,20 @@ class _BaseWithShade(_Base):
             msgs.append(ishd.check_planar(tolerance, False))
         return '\n'.join([m for m in msgs if m != ''])
 
-    def _check_self_intersecting_shades(self,):
+    def _check_self_intersecting_shades(self, tolerance):
         """Check that no edges of the indoor or outdoor shades self-intersect."""
         msgs = []
         for oshd in self._outdoor_shades:
-            msgs.append(oshd.check_self_intersecting(False))
+            msgs.append(oshd.check_self_intersecting(tolerance, False))
         for ishd in self._indoor_shades:
-            msgs.append(ishd.check_self_intersecting(False))
+            msgs.append(ishd.check_self_intersecting(tolerance, False))
         return '\n'.join([m for m in msgs if m != ''])
 
     def _check_non_zero_shades(self, tolerance=0.0001):
         """Check that the indoor or outdoor shades are above a "zero" area tolerance."""
         msgs = []
         for oshd in self._outdoor_shades:
-           msgs.append(oshd.check_non_zero(tolerance, False))
+            msgs.append(oshd.check_non_zero(tolerance, False))
         for ishd in self._indoor_shades:
             msgs.append(ishd.check_non_zero(tolerance, False))
         return '\n'.join([m for m in msgs if m != ''])

--- a/honeybee/aperture.py
+++ b/honeybee/aperture.py
@@ -612,15 +612,27 @@ class Aperture(_BaseWithShade):
             return msg
         return ''
 
-    def check_self_intersecting(self, raise_exception=True):
-        """Check whether the edges of the Aperture intersect one another (like a bowtie)
+    def check_self_intersecting(self, tolerance=0.01, raise_exception=True):
+        """Check whether the edges of the Aperture intersect one another (like a bowtie).
+
+        Note that objects that have duplicate vertices will not be considered
+        self-intersecting and are valid in honeybee.
 
         Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent. Default: 0.01,
+                suitable for objects in meters.
             raise_exception: If True, a ValueError will be raised if the object
                 intersects with itself. Default: True.
         """
         if self.geometry.is_self_intersecting:
             msg = 'Aperture "{}" has self-intersecting edges.'.format(self.full_id)
+            try:  # see if it is self-intersecting because of a duplicate vertex
+                new_geo = self.geometry.remove_colinear_vertices(tolerance)
+                if not new_geo.is_self_intersecting:
+                    return ''  # removing the duplicate vertex makes it self-intersecting
+            except AssertionError:
+                pass  # zero area face; treat it as self-intersecting
             if raise_exception:
                 raise ValueError(msg)
             return msg

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -1090,15 +1090,27 @@ class Face(_BaseWithShade):
             return msg
         return ''
 
-    def check_self_intersecting(self, raise_exception=True):
+    def check_self_intersecting(self, tolerance=0.01, raise_exception=True):
         """Check whether the edges of the Face intersect one another (like a bowtie).
 
+        Note that objects that have duplicate vertices will not be considered
+        self-intersecting and are valid in honeybee.
+
         Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent. Default: 0.01,
+                suitable for objects in meters.
             raise_exception: If True, a ValueError will be raised if the object
                 intersects with itself. Default: True.
         """
         if self.geometry.is_self_intersecting:
             msg = 'Face "{}" has self-intersecting edges.'.format(self.full_id)
+            try:  # see if it is self-intersecting because of a duplicate vertex
+                new_geo = self.geometry.remove_colinear_vertices(tolerance)
+                if not new_geo.is_self_intersecting:
+                    return ''  # removing the duplicate vertex makes it self-intersecting
+            except AssertionError:
+                pass  # zero area face; treat it as self-intersecting
             if raise_exception:
                 raise ValueError(msg)
             return msg

--- a/honeybee/model.py
+++ b/honeybee/model.py
@@ -976,7 +976,7 @@ class Model(_Base):
         tol = self.tolerance
         ang_tol = self.angle_tolerance
         # perform several checks for key geometry rules
-        msgs.append(self.check_self_intersecting(False))
+        msgs.append(self.check_self_intersecting(tol, False))
         msgs.append(self.check_planar(tol, False))
         msgs.append(self.check_sub_faces_valid(tol, ang_tol, False))
         msgs.append(self.check_rooms_solid(tol, ang_tol, False))
@@ -1143,24 +1143,27 @@ class Model(_Base):
             raise ValueError(full_msg)
         return full_msg
 
-    def check_self_intersecting(self, raise_exception=True):
+    def check_self_intersecting(self, tolerance=0.01, raise_exception=True):
         """Check that no edges of the Model's geometry components self-intersect.
 
         This includes all of the Model's Faces, Apertures, Doors and Shades.
 
         Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent. Default: 0.01,
+                suitable for objects in meters.
             raise_exception: If True, a ValueError will be raised if an object
                 intersects with itself (like a bowtie). Default: True.
         """
         msgs = []
         for face in self.faces:
-            msgs.append(face.check_self_intersecting(raise_exception))
+            msgs.append(face.check_self_intersecting(tolerance, raise_exception=False))
         for shd in self.shades:
-            msgs.append(shd.check_self_intersecting(raise_exception))
+            msgs.append(shd.check_self_intersecting(tolerance, raise_exception=False))
         for ap in self.apertures:
-            msgs.append(ap.check_self_intersecting(raise_exception))
+            msgs.append(ap.check_self_intersecting(tolerance, raise_exception=False))
         for dr in self.doors:
-            msgs.append(dr.check_self_intersecting(raise_exception))
+            msgs.append(dr.check_self_intersecting(tolerance, raise_exception=False))
         full_msgs = [msg for msg in msgs if msg != '']
         full_msg = '\n'.join(full_msgs)
         if raise_exception and len(full_msgs) != 0:

--- a/honeybee/room.py
+++ b/honeybee/room.py
@@ -792,26 +792,32 @@ class Room(_BaseWithShade):
             raise ValueError(full_msg)
         return full_msg
 
-    def check_self_intersecting(self, raise_exception=True):
+    def check_self_intersecting(self, tolerance=0.01, raise_exception=True):
         """Check that no edges of the Room's geometry components self-intersect.
 
         This includes all of the Room's Faces, Apertures, Doors and Shades.
 
         Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent. Default: 0.01,
+                suitable for objects in meters.
             raise_exception: If True, a ValueError will be raised if an object
                 intersects with itself (like a bowtie). Default: True.
         """
-        msgs = [self._check_self_intersecting_shades()]
+        msgs = [self._check_self_intersecting_shades(tolerance)]
         for face in self._faces:
-            msgs.append(face.check_self_intersecting(False))
-            msgs.append(face._check_self_intersecting_shades())
+            msgs.append(face.check_self_intersecting(tolerance, False))
+            msgs.append(face._check_self_intersecting_shades(tolerance))
             for ap in face._apertures:
-                msgs.append(ap.check_self_intersecting(False))
-                msgs.append(ap._check_self_intersecting_shades())
+                msgs.append(ap.check_self_intersecting(tolerance, False))
+                msgs.append(ap._check_self_intersecting_shades(tolerance))
             for dr in face._doors:
-                msgs.append(dr.check_self_intersecting(False))
-                msgs.append(dr._check_self_intersecting_shades())
+                msgs.append(dr.check_self_intersecting(tolerance, False))
+                msgs.append(dr._check_self_intersecting_shades(tolerance))
         full_msgs = [msg for msg in msgs if msg != '']
+        if len(full_msgs) != 0:
+            rm_mg = 'Room "{}" contains self-intersecting geometry.'.format(self.full_id)
+            full_msgs.insert(0, rm_mg)
         full_msg = '\n'.join(full_msgs)
         if raise_exception and len(full_msgs) != 0:
             raise ValueError(full_msg)

--- a/honeybee/shade.py
+++ b/honeybee/shade.py
@@ -288,15 +288,24 @@ class Shade(_Base):
             return msg
         return ''
 
-    def check_self_intersecting(self, raise_exception=True):
+    def check_self_intersecting(self, tolerance=0.01, raise_exception=True):
         """Check whether the edges of the Shade intersect one another (like a bowtie).
 
         Args:
+            tolerance: The minimum difference between the coordinate values of two
+                vertices at which they can be considered equivalent. Default: 0.01,
+                suitable for objects in meters.
             raise_exception: If True, a ValueError will be raised if the object
                 intersects with itself. Default: True.
         """
         if self.geometry.is_self_intersecting:
             msg = 'Shade "{}" has self-intersecting edges.'.format(self.full_id)
+            try:  # see if it is self-intersecting because of a duplicate vertex
+                new_geo = self.geometry.remove_colinear_vertices(tolerance)
+                if not new_geo.is_self_intersecting:
+                    return ''  # removing the duplicate vertex makes it self-intersecting
+            except AssertionError:
+                pass  # zero area face; treat it as self-intersecting
             if raise_exception:
                 raise ValueError(msg)
             return msg

--- a/tests/aperture_test.py
+++ b/tests/aperture_test.py
@@ -383,14 +383,14 @@ def test_check_self_intersecting():
     aperture_3 = Aperture('Window3', Face3D(pts_1, plane_2))
     aperture_4 = Aperture('Window4', Face3D(pts_2, plane_2))
 
-    assert aperture_1.check_self_intersecting(False) == ''
-    assert aperture_2.check_self_intersecting(False) != ''
+    assert aperture_1.check_self_intersecting(0.01, False) == ''
+    assert aperture_2.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert aperture_2.check_self_intersecting(True)
-    assert aperture_3.check_self_intersecting(False) == ''
-    assert aperture_4.check_self_intersecting(False) != ''
+        assert aperture_2.check_self_intersecting(0.01, True)
+    assert aperture_3.check_self_intersecting(0.01, False) == ''
+    assert aperture_4.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert aperture_4.check_self_intersecting(True)
+        assert aperture_4.check_self_intersecting(0.01, True)
 
 
 def test_check_non_zero():

--- a/tests/door_test.py
+++ b/tests/door_test.py
@@ -284,14 +284,14 @@ def test_check_self_intersecting():
     door_3 = Door('Door3', Face3D(pts_1, plane_2))
     door_4 = Door('Door4', Face3D(pts_2, plane_2))
 
-    assert door_1.check_self_intersecting(False) == ''
-    assert door_2.check_self_intersecting(False) != ''
+    assert door_1.check_self_intersecting(0.01, False) == ''
+    assert door_2.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert door_2.check_self_intersecting(True)
-    assert door_3.check_self_intersecting(False) == ''
-    assert door_4.check_self_intersecting(False) != ''
+        assert door_2.check_self_intersecting(0.01, True)
+    assert door_3.check_self_intersecting(0.01, False) == ''
+    assert door_4.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert door_4.check_self_intersecting(True)
+        assert door_4.check_self_intersecting(0.01, True)
 
 
 def test_check_non_zero():

--- a/tests/face_test.py
+++ b/tests/face_test.py
@@ -652,14 +652,14 @@ def test_check_self_intersecting():
     face_3 = Face('Wall3', Face3D(pts_1, plane_2))
     face_4 = Face('Wall4', Face3D(pts_2, plane_2))
 
-    assert face_1.check_self_intersecting(False) == ''
-    assert face_2.check_self_intersecting(False) != ''
+    assert face_1.check_self_intersecting(0.01, False) == ''
+    assert face_2.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert face_2.check_self_intersecting(True)
-    assert face_3.check_self_intersecting(False) == ''
-    assert face_4.check_self_intersecting(False) != ''
+        assert face_2.check_self_intersecting(0.01, True)
+    assert face_3.check_self_intersecting(0.01, False) == ''
+    assert face_4.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert face_4.check_self_intersecting(True)
+        assert face_4.check_self_intersecting(0.01, True)
 
 
 def test_check_non_zero():

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -797,10 +797,10 @@ def test_check_self_intersecting():
 
     model_1 = Model('SouthHouse', [room_1])
     model_2 = Model('NorthHouse', [room_2])
-    assert model_1.check_self_intersecting(False) == ''
-    assert model_2.check_self_intersecting(False) != ''
+    assert model_1.check_self_intersecting(0.01, False) == ''
+    assert model_2.check_self_intersecting(0.01, False) != ''
     with pytest.raises(ValueError):
-        model_2.check_self_intersecting(True)
+        model_2.check_self_intersecting(0.01, True)
 
 
 def test_check_non_zero():

--- a/tests/room_test.py
+++ b/tests/room_test.py
@@ -489,8 +489,8 @@ def test_check_self_intersecting():
     room_2 = Room('ZoneSHOE_BOX920980',
                   [face_1, face_2, face_3, face_4, face_5, face_7, face_8], 0.01, 1)
 
-    assert room_1.check_self_intersecting(False) == ''
-    assert room_2.check_self_intersecting(False) != ''
+    assert room_1.check_self_intersecting(0.01, False) == ''
+    assert room_2.check_self_intersecting(0.01, False) != ''
 
 
 def test_check_non_zero():

--- a/tests/shade_test.py
+++ b/tests/shade_test.py
@@ -244,14 +244,14 @@ def test_check_self_intersecting():
     shade_3 = Shade('shade3', Face3D(pts_1, plane_2))
     shade_4 = Shade('shade4', Face3D(pts_2, plane_2))
 
-    assert shade_1.check_self_intersecting(False) == ''
-    assert shade_2.check_self_intersecting(False) != ''
+    assert shade_1.check_self_intersecting(0.01, False) == ''
+    assert shade_2.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert shade_2.check_self_intersecting(True)
-    assert shade_3.check_self_intersecting(False) == ''
-    assert shade_4.check_self_intersecting(False) != ''
+        assert shade_2.check_self_intersecting(0.01, True)
+    assert shade_3.check_self_intersecting(0.01, False) == ''
+    assert shade_4.check_self_intersecting(0.01, False) != ''
     with pytest.raises(Exception):
-        assert shade_4.check_self_intersecting(True)
+        assert shade_4.check_self_intersecting(0.01, True)
 
 
 def test_check_non_zero():


### PR DESCRIPTION
Now, people will not get the self-interesting error if it's because the Face contains a duplicate vertex.

Also, the error messages will contain the Room ID.