### PR TITLE
HB Obj Duplicate Properties to allow for more than .energy and .radiance

### DIFF
--- a/honeybee/properties.py
+++ b/honeybee/properties.py
@@ -163,7 +163,7 @@ class _Properties(object):
             original_properties: The properties object of the original core
                 object from which the duplicate was derived.
         """
-        for atr in self._extension_attributes:
+        for atr in original_properties._extension_attributes:
             var = getattr(original_properties, atr)
             if not hasattr(var, 'duplicate'):
                 continue


### PR DESCRIPTION
When calling `.duplicate()` on an HB Object (Room, etc) during `__copy__()`, the object's properties also get duplicated using the [_duplicate_extension_attr](https://github.com/ladybug-tools/honeybee-core/blob/1dc780de12a571a07f76fc9077cf057d9f9b34a7/honeybee/room.py#L1248) method, called by the 'new' object, with the original object's properties passed in as the argument.

```python
    def __copy__(self):
        new_r = Room(self.identifier, tuple(face.duplicate() for face in self._faces))
        ...
        new_r._properties._duplicate_extension_attr(self._properties) #<--- 
        return new_r
```

To duplicate the property object, within the [_duplicate_extension_attr()](https://github.com/ladybug-tools/honeybee-core/blob/1dc780de12a571a07f76fc9077cf057d9f9b34a7/honeybee/properties.py#L153) the code then steps through the [self._extension_attributes](https://github.com/ladybug-tools/honeybee-core/blob/1dc780de12a571a07f76fc9077cf057d9f9b34a7/honeybee/properties.py#L166). However, this assumes that the property object names to duplicate already exist on the 'new' object (self) which is true for .energy and .radiance, but would not be true for any custom user-determined property objects other than .radiance and .energy. (Unless the parent classes have been modified / sub-classed and the new custom properties added ahead of time.)

```python
    def _duplicate_extension_attr(self, original_properties):
        for atr in self._extension_attributes: # <------
            var = getattr(original_properties, atr)
            if not hasattr(var, 'duplicate'):
                continue
            try:
                setattr(self, '_' + atr, var.duplicate(self.host))
            except Exception as e:
                ...
```

By revising `self._extension_attributes` to `original_properties._extension_attributes`, the HB Object's `duplicate()` can now work for any properties object present on the HB-Obj. This allows for properties other than .radiance and .energy. to be added (assuming it passes the `hasattr(..., ,'duplicate')` guard).

Note that I think this will only result in a duplication of a user-added property object which is private ("_" prefix) and no duplication of any public getter? I'm not sure if that is ok or not? It seems that for user-added properties, having them always private is ok? Or if properties are supposed to be 'registering' with the host class somehow prior to any of this duplication code, this may be irrelevant, as then they would already be present on the self in the above example? 