### PR TITLE
fix(typing): Add method to raise informative serialization errors

### DIFF
--- a/honeybee/dictutil.py
+++ b/honeybee/dictutil.py
@@ -12,6 +12,7 @@ from honeybee.aperture import Aperture
 from honeybee.door import Door
 from honeybee.shade import Shade
 import honeybee.boundarycondition as hbc
+from honeybee.typing import invalid_dict_error
 
 
 def dict_to_object(honeybee_dict, raise_exception=True):
@@ -35,20 +36,23 @@ def dict_to_object(honeybee_dict, raise_exception=True):
     except KeyError:
         raise ValueError('Honeybee dictionary lacks required "type" key.')
 
-    if obj_type == 'Model':
-        return Model.from_dict(honeybee_dict)
-    elif obj_type == 'Room':
-        return Room.from_dict(honeybee_dict)
-    elif obj_type == 'Face':
-        return Face.from_dict(honeybee_dict)
-    elif obj_type == 'Aperture':
-        return Aperture.from_dict(honeybee_dict)
-    elif obj_type == 'Door':
-        return Door.from_dict(honeybee_dict)
-    elif obj_type == 'Shade':
-        return Shade.from_dict(honeybee_dict)
-    elif hasattr(hbc, obj_type):
-        bc_class = getattr(hbc, obj_type)
-        return bc_class.from_dict(honeybee_dict)
-    elif raise_exception:
-        raise ValueError('{} is not a recognized honeybee object'.format(obj_type))
+    try:
+        if obj_type == 'Model':
+            return Model.from_dict(honeybee_dict)
+        elif obj_type == 'Room':
+            return Room.from_dict(honeybee_dict)
+        elif obj_type == 'Face':
+            return Face.from_dict(honeybee_dict)
+        elif obj_type == 'Aperture':
+            return Aperture.from_dict(honeybee_dict)
+        elif obj_type == 'Door':
+            return Door.from_dict(honeybee_dict)
+        elif obj_type == 'Shade':
+            return Shade.from_dict(honeybee_dict)
+        elif hasattr(hbc, obj_type):
+            bc_class = getattr(hbc, obj_type)
+            return bc_class.from_dict(honeybee_dict)
+        elif raise_exception:
+            raise ValueError('{} is not a recognized honeybee object'.format(obj_type))
+    except Exception as e:
+        invalid_dict_error(honeybee_dict, e)

--- a/honeybee/typing.py
+++ b/honeybee/typing.py
@@ -268,6 +268,25 @@ def clean_and_id_ep_string(value, input_name=''):
     return val + '_' + str(uuid.uuid4())[:8]
 
 
+def invalid_dict_error(invalid_dict, error):
+    """Raise a ValueError for an invalid dictionary that failed to serialize.
+
+    This error message will include the identifier (and display_name) if they are
+    present within the invalid_dict, making it easier for ens users to find the
+    invalid object within large objects like Models.
+
+    Args:
+        invalid_dict: A dictionary of an invalid honeybee object that failed
+            to serialize.
+        error:
+    """
+    obj_type = invalid_dict['type'] if 'type' in invalid_dict else 'Honeybee Object'
+    obj_id = invalid_dict['identifier'] if 'identifier' in invalid_dict else ''
+    full_id = '{}[{}]'.format(invalid_dict['display_name'], obj_id) \
+        if 'display_name' in invalid_dict else obj_id
+    raise ValueError('{} "{}" is invalid:\n{}'.format(obj_type, full_id, error))
+
+
 wrapper = '"' if os.name == 'nt' else '\''
 """String wrapper."""
 

--- a/tests/typing_test.py
+++ b/tests/typing_test.py
@@ -3,7 +3,8 @@ from honeybee.typing import clean_string, clean_rad_string, clean_ep_string, \
     float_in_range, int_in_range, float_positive, int_positive, \
     tuple_with_length, list_with_length, normpath, \
     clean_and_id_string, clean_and_id_rad_string, clean_and_id_ep_string, \
-    float_in_range_excl, float_in_range_excl_incl, float_in_range_incl_excl
+    float_in_range_excl, float_in_range_excl_incl, float_in_range_incl_excl, \
+    invalid_dict_error
 
 import pytest
 
@@ -70,7 +71,7 @@ def test_clean_and_id_rad_string():
     assert len(clean_and_id_rad_string(long_str)) > 70
 
 
-def test_clean_ep_string():
+def test_clean_and_id_ep_string():
     """Test the clean_and_id_ep_string method."""
     correct_str = '1/2 in. Gypsum Board'
     incorrect_str = '1/2 in., Gypsum Board!'
@@ -240,3 +241,16 @@ def test_list_with_length():
         list_with_length((1, 2, 3), 4, float, 'test list')
     except AssertionError as e:
         assert 'test list' in str(e)
+
+
+def test_invalid_dict_error():
+    """Test the invalid_dict_errormethod."""
+    inv_dict = {
+        'type': 'Construction',
+        'identifier': 'no_heat_capacity_construction',
+        'display_name': 'User-Created Construction'
+    }
+    error_msg = 'Construction does not contain sufficient heat capacity.'
+
+    with pytest.raises(ValueError):
+        invalid_dict_error(inv_dict, error_msg)


### PR DESCRIPTION
I imagine that we will use this throughout the extensions to give better error messages about invalid objects.