### PR TITLE
fix(room): Add more reliable method to clean envelope geometry

### DIFF
--- a/honeybee/boundarycondition.py
+++ b/honeybee/boundarycondition.py
@@ -13,7 +13,6 @@ class _BoundaryCondition(object):
     def __init__(self):
         """Initialize Boundary condition."""
 
-
     @property
     def name(self):
         """Get the name of the boundary condition (ie. 'Outdoors', 'Ground')."""
@@ -152,8 +151,8 @@ class Surface(_BoundaryCondition):
         """Initialize Surface boundary condition.
 
         Args:
-            boundary_condition_objects: A list of up to 3 object identifiers that are adjacent
-                to this one. The first object is always the one that is immediately
+            boundary_condition_objects: A list of up to 3 object identifiers that are
+                adjacent to this one. The first object is always immediately
                 adjacent and is of the same object type (Face, Aperture, Door). When
                 this boundary condition is applied to a Face, the second object in the
                 tuple will be the parent Room of the adjacent object. When the boundary

--- a/honeybee/cli/edit.py
+++ b/honeybee/cli/edit.py
@@ -92,7 +92,7 @@ def solve_adjacency(model_file, wall, surface, no_intersect, no_overwrite, outpu
             'Model must have a non-zero tolerance to use solve-adjacency.'
         tol, ang_tol = parsed_model.tolerance, parsed_model.angle_tolerance
 
-         # intersect adjacencies if requested
+        # intersect adjacencies if requested
         if not no_intersect:
             Room.intersect_adjacency(parsed_model.rooms, tol, ang_tol)
 

--- a/honeybee/face.py
+++ b/honeybee/face.py
@@ -271,7 +271,7 @@ class Face(_BaseWithShade):
 
     @property
     def punched_geometry(self):
-        """Get a ladybug_geometry Face3D object with holes cut in it for apertures and doors.
+        """Get a Face3D object with holes cut in it for apertures and doors.
         """
         if self._punched_geometry is None:
             _sub_faces = tuple(sub_f.geometry for sub_f in self._apertures + self._doors)
@@ -313,7 +313,7 @@ class Face(_BaseWithShade):
 
     @property
     def normal(self):
-        """Get a ladybug_geometry Vector3D for the direction in which the face is pointing.
+        """Get a Vector3D for the direction in which the face is pointing.
         """
         return self._geometry.normal
 
@@ -427,7 +427,7 @@ class Face(_BaseWithShade):
         return orient_text[0]
 
     def add_prefix(self, prefix):
-        """Change the identifier of this object and all child objects by inserting a prefix.
+        """Change the identifier of this object and child objects by inserting a prefix.
 
         This is particularly useful in workflows where you duplicate and edit
         a starting object and then want to combine it with the original object


### PR DESCRIPTION
This new method is more reliable at ensuring adjacent Faces have matching numbers of vertices whenever there are duplicated colinear vertices.

The commit also improves the adjacency validation check so that it not only catches cases of mismatched areas but also different shapes within the tolerance.